### PR TITLE
mirrorlist: Let WebOb determine the Content-Length for us.

### DIFF
--- a/mirrorlist/mirrorlist_client.wsgi
+++ b/mirrorlist/mirrorlist_client.wsgi
@@ -174,7 +174,6 @@ def application(environ, start_response):
         response.headers['Content-Type'] = "text/plain"
 
     results = results.encode('utf-8')
-    response.headers['Content-Length'] = str(len(results))
     response.write(results)
     return response(environ, start_response)
 


### PR DESCRIPTION
This fixes the following error that started happening
after porting from paste to webob:

curl: (18) transfer closed with 9271 bytes remaining to read
