### PR TITLE
Fix host selection logic in the crawler.

### DIFF
--- a/utility/mm2_crawler
+++ b/utility/mm2_crawler
@@ -66,11 +66,10 @@ def doit(options, config):
         host for host in hosts if (
             not host.id < options.startid and
             not host.id >= options.stopid and
-            not (
-                host.admin_active and
-                host.user_active and
-                host.site.user_active and
-                host.site.admin_active) and
+            ( host.admin_active and
+              host.user_active and
+              host.site.user_active and
+              host.site.admin_active) and
             not host.site.private)
     ]
 


### PR DESCRIPTION
If any of the active fields is not set the host is disabled;
Not the other way around.