### PR TITLE
Print out the rsync command (including parameters)

### DIFF
--- a/mirrormanager2/lib/sync.py
+++ b/mirrormanager2/lib/sync.py
@@ -27,12 +27,14 @@ import subprocess
 import tempfile
 
 
-def run_rsync(rsyncpath, extra_rsync_args=None):
+def run_rsync(rsyncpath, extra_rsync_args=None, logger=None):
     tmpfile = tempfile.SpooledTemporaryFile()
     cmd = "rsync --temp-dir=/tmp -r --exclude=.snapshot --exclude='*.~tmp~'"
     if extra_rsync_args is not None:
         cmd += ' ' + extra_rsync_args
     cmd += ' ' + rsyncpath
+    if logger is not None:
+        logger.info("About to run following rsync command: " + cmd)
     devnull = open('/dev/null', 'r+')
     p = subprocess.Popen(
         cmd,

--- a/utility/mm2_crawler
+++ b/utility/mm2_crawler
@@ -646,7 +646,7 @@ def try_per_category(
 
     rsync_start_time = datetime.datetime.utcnow()
     try:
-        result, listing = run_rsync(url, '--no-motd')
+        result, listing = run_rsync(url, '--no-motd', logger)
     except:
         logger.warning('Failed to run rsync.', exc_info = True)
         return False

--- a/utility/mm2_update-master-directory-list
+++ b/utility/mm2_update-master-directory-list
@@ -623,7 +623,7 @@ def parse_rsync_listing(session, config, category, f):
 
 def sync_directories_using_rsync(session, config, rsyncpath, category):
     try:
-        result, output = run_rsync(rsyncpath, category.extra_rsync_options)
+        result, output = run_rsync(rsyncpath, category.extra_rsync_options, logger)
     except:
         logger.warning('Failed to run rsync.', exc_info = True)
         return


### PR DESCRIPTION
For better problem analysis it is helpful to know
which rsync command is actually used by MirrorManager.