### PR TITLE
Add the possibility to influence rsync crawler

### DIFF
--- a/mirrormanager2/default_config.py
+++ b/mirrormanager2/default_config.py
@@ -88,3 +88,9 @@ APPLICATION_URL = None
 # under certain setup it might not work (for example is there are proxies
 # in front of the application).
 CHECK_SESSION_IP = True
+
+# Specify additional rsync parameters for the crawler
+# --timeout 14400: abort rsync crawl after 4 hours
+# Depending on the setup and the crawler frequency rsync's timeout option
+# can be used decrease the probability of stale rsync processes
+CRAWLER_RSYNC_PARAMETERS = '--no-motd --timeout 14400'

--- a/utility/mirrormanager2.cfg.sample
+++ b/utility/mirrormanager2.cfg.sample
@@ -94,6 +94,9 @@ CHECK_SESSION_IP = True
 # Specify whether the crawler should send a report by email
 CRAWLER_SEND_EMAIL =  True
 
+# Specify additional rsync parameters for the crawler
+# # --timeout 14400: abort rsync crawl after 4 hours
+CRAWLER_RSYNC_PARAMETERS = '--no-motd --timeout 14400'
 
 umdl_master_directories = [
     {

--- a/utility/mm2_crawler
+++ b/utility/mm2_crawler
@@ -645,8 +645,9 @@ def try_per_category(
         url += '/'
 
     rsync_start_time = datetime.datetime.utcnow()
+    params = config.get('CRAWLER_RSYNC_PARAMETERS', '--no-motd')
     try:
-        result, listing = run_rsync(url, '--no-motd', logger)
+        result, listing = run_rsync(url, params, logger)
     except:
         logger.warning('Failed to run rsync.', exc_info = True)
         return False


### PR DESCRIPTION
Until now the command-line options of the rsync command to
crawl rsync mirrors has been hardcoded. This gives the option
to influence those those command-line options from the
configuration file.