### PR TITLE
Enable per crawler thread logging

### DIFF
--- a/mirrormanager2/default_config.py
+++ b/mirrormanager2/default_config.py
@@ -94,3 +94,8 @@ CHECK_SESSION_IP = True
 # Depending on the setup and the crawler frequency rsync's timeout option
 # can be used decrease the probability of stale rsync processes
 CRAWLER_RSYNC_PARAMETERS = '--no-motd --timeout 14400'
+
+# If this variable is set (and the directory exists)
+# the crawler will create per host log files with <hostid>.log
+# which can the be used in the web interface by the mirror admins
+CRAWLER_LOG_DIR = '/var/log/mirrormanager/crawler'

--- a/utility/mirrormanager2.cfg.sample
+++ b/utility/mirrormanager2.cfg.sample
@@ -98,6 +98,11 @@ CRAWLER_SEND_EMAIL =  True
 # # --timeout 14400: abort rsync crawl after 4 hours
 CRAWLER_RSYNC_PARAMETERS = '--no-motd --timeout 14400'
 
+# If this variable is set (and the directory exists)
+# # the crawler will create per host log files with <hostid>.log
+# # which can the be used in the web interface by the mirror admins
+CRAWLER_LOG_DIR = '/var/log/mirrormanager/crawler'
+
 umdl_master_directories = [
     {
         'type': 'directory',

--- a/utility/mirrormanager2.spec
+++ b/utility/mirrormanager2.spec
@@ -133,6 +133,8 @@ rm -rf $RPM_BUILD_ROOT
 mkdir -p $RPM_BUILD_ROOT/%{_sysconfdir}/httpd/conf.d/
 # MirrorManager configuration file
 mkdir -p $RPM_BUILD_ROOT/%{_sysconfdir}/mirrormanager
+# MirrorManager crawler log rotation
+mkdir -p $RPM_BUILD_ROOT/%{_sysconfdir}/logrotate.d
 # for .wsgi files mainly
 mkdir -p $RPM_BUILD_ROOT/%{_datadir}/mirrormanager2
 # Stores temp files (.sock & co)
@@ -141,6 +143,8 @@ mkdir -p $RPM_BUILD_ROOT/%{_sharedstatedir}/mirrormanager
 mkdir -p $RPM_BUILD_ROOT/%{_localstatedir}/lock/mirrormanager
 # Stores lock and pid info
 mkdir -p $RPM_BUILD_ROOT/%{_localstatedir}/run/mirrormanager
+# Log files
+mkdir -p $RPM_BUILD_ROOT/%{_localstatedir}/log/mirrormanager/crawler
 # Stores the service file for systemd
 mkdir -p $RPM_BUILD_ROOT/%{_unitdir}
 
@@ -153,6 +157,10 @@ install -m 644 utility/mirrormanager.conf.sample \
 # Install configuration file
 install -m 644 utility/mirrormanager2.cfg.sample \
     $RPM_BUILD_ROOT/%{_sysconfdir}/mirrormanager/mirrormanager2.cfg
+
+# Install crawler logrotate definition
+install -m 644 utility/mm2_crawler.logrotate \
+    $RPM_BUILD_ROOT/%{_sysconfdir}/logrotate.d/mm2_crawler
 
 # Install WSGI file
 install -m 644 utility/mirrormanager2.wsgi \
@@ -219,6 +227,8 @@ cp -r utility/zebra-dump-parser $RPM_BUILD_ROOT/%{_datadir}/mirrormanager2/
 
 
 %files crawler
+%config(noreplace) %{_sysconfdir}/logrotate.d/mm2_crawler
+%{_localstatedir}/log/mirrormanager/
 %{_bindir}/mm2_crawler
 
 

--- a/utility/mm2_crawler
+++ b/utility/mm2_crawler
@@ -24,6 +24,7 @@ from mirrormanager2.lib.sync import run_rsync
 
 
 logger = logging.getLogger("crawler")
+formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
 
 
 # This is a "thread local" object that allows us to store the start time of
@@ -31,6 +32,14 @@ logger = logging.getLogger("crawler")
 # not...)
 threadlocal = threading.local()
 
+# This filter is necessary to enable logging per thread into a separate file
+# Based on http://plumberjack.blogspot.de/2010/09/configuring-logging-for-web.html
+class InjectingFilter(logging.Filter):
+    def __init__(self, thread_id):
+        self.thread_id = thread_id
+
+    def filter(self, record):
+        return threadlocal.thread_id == self.thread_id
 
 def thread_id():
     """ Silly util that returns a git-style short-hash id of the thread. """
@@ -973,6 +982,30 @@ def per_host(session, host, options, config):
 
 
 def worker(options, config, host):
+    # setup per thread file logger
+    log_dir = config.get('CRAWLER_LOG_DIR', None)
+    # check if the directory exists
+    if log_dir is not None:
+        if not os.path.isdir(log_dir):
+            # CRAWLER_LOG_DIR seems to be configured but does not exist
+            # not logging
+            logger.warning("Directory " + log_dir + " does not exists."
+                           " Not logging per host")
+            log_dir = None
+
+    if log_dir is not None:
+        fh = logging.FileHandler(log_dir + "/" + str(host.id) + '.log')
+        threadlocal.thread_id = thread_id()
+        f = InjectingFilter(thread_id())
+        fh.addFilter(f)
+
+        if options.debug:
+            fh.setLevel(logging.DEBUG)
+        else:
+            fh.setLevel(logging.INFO)
+        fh.setFormatter(formatter)
+        logger.addHandler(fh)
+
     logger.info("Worker %r starting on host %r" % (thread_id(), host))
     threadlocal.starttime = time.time()
 

--- a/utility/mm2_crawler.logrotate
+++ b/utility/mm2_crawler.logrotate
@@ -1,0 +1,9 @@
+/var/log/mirrormanager/crawler/*log {
+    missingok
+    notifempty
+    daily
+    dateext
+    rotate 15
+    postrotate
+    endscript
+}


### PR DESCRIPTION
MM1 used to log for each crawler the output under <hostid>.log.
This adds the per host logging to the new thread based design.
These log files are referenced on each host page in the web
interface.