### PR TITLE
Close per thread logging correctly.

### DIFF
--- a/utility/mm2_crawler
+++ b/utility/mm2_crawler
@@ -1031,6 +1031,8 @@ def worker(options, config, host):
         rc = 3
 
     logger.info("Ending crawl of %r with status %r" % (host, rc))
+    logger.removeHandler(fh)
+    fh.close()
     return rc
 
 


### PR DESCRIPTION
If the crawler was running for some time the per thread
file logging would start to log to multiple files. Now,
with the removal and closing of the FileHandler the
logging works as it is expected to.