### PR TITLE
Add more informations to the log output.

### DIFF
--- a/utility/mm2_crawler
+++ b/utility/mm2_crawler
@@ -25,12 +25,31 @@ from mirrormanager2.lib.sync import run_rsync
 
 logger = logging.getLogger("crawler")
 formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
+master_formatter = "%(levelname)s:%(name)s:%(hosts)s:%(threads)s:%(hostid)s:%(hostname)s:%(message)s"
+current_host = 0
+all_hosts = 0
+threads = 0
+threads_active = 0
 
 
 # This is a "thread local" object that allows us to store the start time of
 # each worker thread (so they can measure and check if they should time out or
 # not...)
 threadlocal = threading.local()
+
+# To insert information about the number of hosts and threads in each master
+# log message this filter is necessary
+class MasterFilter(logging.Filter):
+    def filter(self, record):
+        record.hosts = "Hosts(%d/%d)" % (current_host, all_hosts)
+        record.threads = "Threads(%d/%d)" % (threads_active, threads)
+        try:
+            record.hostid = threadlocal.hostid
+            record.hostname = threadlocal.hostname
+        except:
+            record.hostid = 0
+            record.hostname = 'master'
+        return True
 
 # This filter is necessary to enable logging per thread into a separate file
 # Based on http://plumberjack.blogspot.de/2010/09/configuring-logging-for-web.html
@@ -64,6 +83,8 @@ def notify(options, topic, msg):
 
 
 def doit(options, config):
+    global all_hosts
+    global threads
 
     session = mirrormanager2.lib.create_session(config['DB_URL'])
 
@@ -81,6 +102,9 @@ def doit(options, config):
               host.site.admin_active) and
             not host.site.private)
     ]
+
+    all_hosts = len(hosts)
+    threads = options.threads
 
     # And then, for debugging, only do one host
     #hosts = [hosts.next()]
@@ -109,7 +133,9 @@ def doit(options, config):
 
 
 def setup_logging(debug):
-    logging.basicConfig()
+    logging.basicConfig(format=master_formatter)
+    f = MasterFilter()
+    logger.addFilter(f)
     if debug:
         logger.setLevel(logging.DEBUG)
     else:
@@ -118,6 +144,7 @@ def setup_logging(debug):
 
 
 def main():
+    starttime = time.time()
     parser = argparse.ArgumentParser(usage=sys.argv[0] + " [options]")
     parser.add_argument(
         "-c", "--config",
@@ -174,6 +201,7 @@ def main():
         exec(compile(config_file.read(), options.config, 'exec'), config)
 
     doit(options, config)
+    logger.info("Crawler finished after %d seconds" % (time.time() - starttime))
     return 0
 
 
@@ -469,6 +497,8 @@ def check_head(hoststate, url, filedata, recursion, readable, retry=0):
 
 
 def report_stats(stats):
+    msg = "Crawl duration: %d seconds" % stats['duration']
+    logger.info(msg)
     msg = "Total directories: %d" % stats['numkeys']
     logger.info(msg)
     msg = "Changed to up2date: %d" % stats['up2date']
@@ -492,6 +522,7 @@ def sync_hcds(session, host, host_category_dirs):
     current_hcds = {}
     host.last_crawled = datetime.datetime.utcnow()
     host.last_crawl_duration = time.time() -  threadlocal.starttime
+    stats['duration'] = host.last_crawl_duration
     keys = host_category_dirs.keys()
     keys = sorted(keys, key = lambda t: t[1].name)
     stats['numkeys'] = len(keys)
@@ -985,6 +1016,14 @@ def per_host(session, host, options, config):
 
 
 def worker(options, config, host):
+    global current_host
+    global threads_active
+    threads_active = threads_active + 1
+    current_host = current_host + 1
+    threadlocal.starttime = time.time()
+    threadlocal.hostid = host.id
+    threadlocal.hostname = host.name
+
     # setup per thread file logger
     log_dir = config.get('CRAWLER_LOG_DIR', None)
     # check if the directory exists
@@ -1010,7 +1049,6 @@ def worker(options, config, host):
         logger.addHandler(fh)
 
     logger.info("Worker %r starting on host %r" % (thread_id(), host))
-    threadlocal.starttime = time.time()
 
     # Each worker gets its own thread
     session = mirrormanager2.lib.create_session(config['DB_URL'])
@@ -1033,6 +1071,7 @@ def worker(options, config, host):
     logger.info("Ending crawl of %r with status %r" % (host, rc))
     logger.removeHandler(fh)
     fh.close()
+    threads_active = threads_active - 1
     return rc
 
 


### PR DESCRIPTION
Add information about the number of active threads and
how many hosts still need to be crawled to the crawler
logging output.