### PR TITLE
Let the database to the work

### DIFF
--- a/utility/mm2_crawler
+++ b/utility/mm2_crawler
@@ -89,18 +89,16 @@ def doit(options, config):
     session = mirrormanager2.lib.create_session(config['DB_URL'])
 
     # Get *all* of the mirrors
-    hosts = mirrormanager2.lib.get_mirrors(session, private=False, order_by_crawl_duration=True)
+    hosts = mirrormanager2.lib.get_mirrors(
+        session, private=False, order_by_crawl_duration=True,
+        admin_active=True, user_active=True, site_private=False,
+        site_user_active=True, site_admin_active=True)
 
     # Limit our host list down to only the ones we really want to crawl
     hosts = [
         host for host in hosts if (
             not host.id < options.startid and
-            not host.id >= options.stopid and
-            ( host.admin_active and
-              host.user_active and
-              host.site.user_active and
-              host.site.admin_active) and
-            not host.site.private)
+            not host.id >= options.stopid)
     ]
 
     all_hosts = len(hosts)


### PR DESCRIPTION
As the functionality is already there only select the hosts
from the database which will actually be used later. By not
selecting anyway unwanted hosts the memory usage should be
also slightly decreased.