### PR TITLE
Ask to build with systemd-devel to simplify

### DIFF
--- a/utility/mirrormanager2.spec
+++ b/utility/mirrormanager2.spec
@@ -29,7 +29,7 @@ BuildRequires:  python-GeoIP
 BuildRequires:  py-radix
 BuildRequires:  python-webob
 
-BuildRequires:  systemd
+BuildRequires:  systemd-devel
 
 # EPEL6
 %if ( 0%{?rhel} && 0%{?rhel} == 6 )


### PR DESCRIPTION
This will bring the definition of the RPM macros used in %files:
%{_tmpfilesdir}/ and %{_unitdir}/