### PR TITLE
run_rsync() returns a temporary file which needs to be closed

### DIFF
--- a/utility/mm2_crawler
+++ b/utility/mm2_crawler
@@ -718,6 +718,9 @@ def try_per_category(
         except IndexError:
             logger.debug("invalid rsync line: %s\n" % line)
 
+    # run_rsync() returns a temporary file which needs to be closed
+    listing.close()
+
     logger.debug("rsync listing has %d lines" % len(rsync))
     if len(rsync) == 0:
         # no rsync content, fail!


### PR DESCRIPTION
Very simple one line fix to close temporary files created by run_rsync()