### PR TITLE
Add a Location tag for static

### DIFF
--- a/mirrorlist/apache/mirrorlist-server.conf
+++ b/mirrorlist/apache/mirrorlist-server.conf
@@ -54,3 +54,15 @@ WSGIScriptAlias /mirrorlist /usr/share/mirrormanager2/mirrorlist_client.wsgi
         Allow from all
     </IfModule>
 </Location>
+
+<Location /static>
+    <IfModule mod_authz_core.c>
+        # Apache 2.4
+        Require all granted
+    </IfModule>
+    <IfModule !mod_authz_core.c>
+        # Apache 2.2
+        Order deny,allow
+        Allow from all
+    </IfModule>
+</Location>


### PR DESCRIPTION
For every alias, you need to have either a Directory or a Location
that matches it.
Source: https://wiki.apache.org/httpd/ClientDeniedByServerConfiguration

Signed-off-by: Patrick Uiterwijk <puiterwijk@redhat.com>