### PR TITLE
Remove another potential segfault

### DIFF
--- a/utility/mm2_crawler
+++ b/utility/mm2_crawler
@@ -96,11 +96,12 @@ def doit(options, config):
 
     # Limit our host list down to only the ones we really want to crawl
     hosts = [
-        host for host in hosts if (
+        host.id for host in hosts if (
             not host.id < options.startid and
             not host.id >= options.stopid)
     ]
 
+    session.close()
     all_hosts = len(hosts)
     threads = options.threads
 
@@ -115,7 +116,7 @@ def doit(options, config):
 
     # Then create a threadpool to handle as many at a time as we like
     threadpool = multiprocessing.pool.ThreadPool(processes=options.threads)
-    fn = lambda host: worker(options, config, host)
+    fn = lambda host_id: worker(options, config, host_id)
 
     # Here's the big operation
     return_codes = threadpool.map(fn, hosts)
@@ -123,9 +124,6 @@ def doit(options, config):
     # Put a bow on the results for fedmsg
     results = [dict(rc=rc, host=host) for rc, host in zip(return_codes, hosts)]
     notify(options, 'complete', dict(results=results))
-
-    session.commit()
-    session.close()
 
     return results
 
@@ -595,6 +593,7 @@ def method_pref(urls, prev=""):
             if u.startswith('ftp:'):
                 pref = u
                 break
+    logger.info("Crawling with URL %s" % pref)
     return pref
 
 
@@ -1031,9 +1030,13 @@ def per_host(session, host, options, config):
     return rc
 
 
-def worker(options, config, host):
+def worker(options, config, host_id):
     global current_host
     global threads_active
+
+    session = mirrormanager2.lib.create_session(config['DB_URL'])
+    host = mirrormanager2.lib.get_host(session, host_id)
+
     threads_active = threads_active + 1
     current_host = current_host + 1
     threadlocal.starttime = time.time()
@@ -1066,8 +1069,6 @@ def worker(options, config, host):
 
     logger.info("Worker %r starting on host %r" % (thread_id(), host))
 
-    # Each worker gets its own thread
-    session = mirrormanager2.lib.create_session(config['DB_URL'])
 
     try:
         rc = per_host(session, host.id, options, config)


### PR DESCRIPTION
The crawler was still crashing sometimes in libpython2.7.so.1.0.
This seems to be related to sqlalchemy and its usage combined with
threads. There was one DB session open in the main thread and for
each worker thread another DB session was opened. This was tracked
at https://fedorahosted.org/mirrormanager/ticket/57

This lead to

python[1156]: segfault at 58 ip 00007fe6fefd59f7 sp 00007fe68a7fa750 error 4 in libpython2.7.so.1.0[7fe6feef9000+178000]

and on the console mm2_crawler was complaining about:

/usr/lib64/python2.7/site-packages/sqlalchemy/orm/session.py:1919: SAWarning: Attribute history events accumulated on 125 previously clean instances within inner-flush event handlers have been reset, and will not result in database updates. Consider using set_committed_value() within inner-flush event handlers to avoid this warning.
  self._flush(objects)
/usr/lib64/python2.7/site-packages/sqlalchemy/orm/session.py:2037: SAWarning: Session's state has been changed on a non-active transaction - this state will be discarded.
  transaction.rollback(_capture_exception=True)
Traceback (most recent call last):
  File "utility/mm2_crawler", line 1148, in <module>
    sys.exit(main())
  File "utility/mm2_crawler", line 201, in main
    doit(options, config)
  File "utility/mm2_crawler", line 121, in doit
    return_codes = threadpool.map(fn, hosts)
  File "/usr/lib64/python2.7/multiprocessing/pool.py", line 250, in map
    return self.map_async(func, iterable, chunksize).get()
  File "/usr/lib64/python2.7/multiprocessing/pool.py", line 554, in get
    raise self._value
AssertionError
Exception in thread Thread-4 (most likely raised during interpreter shutdown):
Traceback (most recent call last):
  File "/usr/lib64/python2.7/threading.py", line 811, in __bootstrap_inner
  File "/usr/lib64/python2.7/threading.py", line 764, in run
  File "/usr/lib64/python2.7/multiprocessing/pool.py", line 108, in worker
<type 'exceptions.TypeError'>: 'NoneType' object is not callableSegmentation fault

Now in the main thread the DB connection is only opened for a short
time to get the list of mirrors and then closed and in each worker thread
the DB connection is opened for each host crawled. This has the additional
advantage that host specific crawler updates are stored in the DB at
the end of each host crawl and not just at the end of the crawler. This also
means, that if the crawler should crash (which it should not) the crawled
hosts are updated correctly in the database.