### PR TITLE
Decrease time required for set_not_up2date()

### DIFF
--- a/mirrormanager2/lib/model.py
+++ b/mirrormanager2/lib/model.py
@@ -262,7 +262,7 @@ class Host(BASE):
         for hc in self.categories:
             for hcd in hc.directories:
                 hcd.up2date = False
-                session.commit()
+        session.commit()
 
     def is_active(self):
         return self.admin_active \

--- a/utility/mm2_crawler
+++ b/utility/mm2_crawler
@@ -867,8 +867,10 @@ def mark_not_up2date(session, config, exc, host, reason="Unknown"):
     It usually is called if the scan of a single category has failed.
     This is something the crawler does at multiple places: Failure
     in the scan of a single category disables the complete host."""
-    host.set_not_up2date(session)
     host.last_crawl_duration = time.time() -  threadlocal.starttime
+    # Watch out: set_not_up2date(session) is commiting all changes
+    # in this thread to the database
+    host.set_not_up2date(session)
     msg = "Host %s marked not up2date: %s" % (host.id, reason)
     logger.warning(msg)
     if exc is not None:


### PR DESCRIPTION
Now that there are more checks if a timeout has occurred it was
observed that the function set_not_up2date() takes enormous amounts
of time to finish. The function is looping over each directory in
a category and marking it as not up to date. Unfortunately there
was a session.commit() after each directory update which required
huge amounts of time. Now all directories are marked as not up to
date and then a single session.commit() is executed.

This is still a bit strange as all other DB accesses and changes
are only committed at the end of a crawler thread and not somewhere
in a function which is outside of the crawler.