### PR TITLE
Add support to auto disable mirrors

### DIFF
--- a/mirrormanager2/default_config.py
+++ b/mirrormanager2/default_config.py
@@ -99,3 +99,7 @@ CRAWLER_RSYNC_PARAMETERS = '--no-motd --timeout 14400'
 # the crawler will create per host log files with <hostid>.log
 # which can the be used in the web interface by the mirror admins
 CRAWLER_LOG_DIR = '/var/log/mirrormanager/crawler'
+
+# If a host fails for CRAWLER_AUTO_DISABLE times in a row
+# the host will be disable automatically (user_active)
+CRAWLER_AUTO_DISABLE = 4

--- a/mirrormanager2/forms.py
+++ b/mirrormanager2/forms.py
@@ -101,6 +101,10 @@ class AddHostForm(wtf.Form):
         'User active',
         default=True
     )
+    disable_reason = wtforms.TextField(
+        'Disable Reason',
+        [wtforms.validators.Optional()],
+    )
     country = wtforms.TextField(
         'Country  <span class="error">*</span>',
         [wtforms.validators.Required()]

--- a/mirrormanager2/templates/fedora/host.html
+++ b/mirrormanager2/templates/fedora/host.html
@@ -23,6 +23,7 @@
     {{ render_field_in_row(form.name) }}
     {{ render_field_in_row(form.admin_active) }}
     {{ render_field_in_row(form.user_active) }}
+    {{ render_field_in_row(form.disable_reason) }}
     {{ render_field_in_row(form.country) }}
     {{ render_field_in_row(form.bandwidth_int) }}
     {{ render_field_in_row(form.private) }}
@@ -48,6 +49,7 @@ Last Checked In: {{ host.last_checked_in or '-' }} <br />
 Last Crawled: {% if host.last_crawled %} {{ host.last_crawled
   }} <a href="{{url_for('index')}}crawler/{{host.id}}.log">[Log]</a> {% else %} - {% endif %} <br />
 Last Crawl Duration: {{ host.last_crawl_duration }} seconds
+{% if host.crawl_failures > 0 %}<br/>Number of consecutive crawl failures: {{ host.crawl_failures }} {% endif %}
 </p>
 
 <h3>

--- a/utility/mirrormanager2.cfg.sample
+++ b/utility/mirrormanager2.cfg.sample
@@ -95,13 +95,17 @@ CHECK_SESSION_IP = True
 CRAWLER_SEND_EMAIL =  True
 
 # Specify additional rsync parameters for the crawler
-# # --timeout 14400: abort rsync crawl after 4 hours
+# --timeout 14400: abort rsync crawl after 4 hours
 CRAWLER_RSYNC_PARAMETERS = '--no-motd --timeout 14400'
 
 # If this variable is set (and the directory exists)
-# # the crawler will create per host log files with <hostid>.log
-# # which can the be used in the web interface by the mirror admins
+# the crawler will create per host log files with <hostid>.log
+# which can the be used in the web interface by the mirror admins
 CRAWLER_LOG_DIR = '/var/log/mirrormanager/crawler'
+
+# If a host fails for CRAWLER_AUTO_DISABLE times in a row
+# the host will be disable automatically (user_active)
+CRAWLER_AUTO_DISABLE = 4
 
 umdl_master_directories = [
     {

--- a/utility/mm2_crawler
+++ b/utility/mm2_crawler
@@ -1075,6 +1075,7 @@ def worker(options, config, host_id):
     try:
         rc = per_host(session, host.id, options, config)
         host.last_crawled = datetime.datetime.utcnow()
+        host.crawl_failures = 0
         session.commit()
     except TimeoutException:
         rc = 2
@@ -1084,6 +1085,16 @@ def worker(options, config, host_id):
             "Crawler timed out before completing.  "
             "Host is likely overloaded.")
         host.last_crawled = datetime.datetime.utcnow()
+        try:
+            host.crawl_failures += 1
+        except TypeError:
+            host.crawl_failures = 1
+        auto_disable = config.get('CRAWLER_AUTO_DISABLE', 4)
+        if host.crawl_failures >= auto_disable:
+            host.disable_reason = "Host has been disabled (user_active) after %d "
+                                  "crawl consecutive crawlfailures" % auto_disable
+            host.user_active = False
+            
         session.commit()
     except Exception:
         logger.exception("Failure in thread %r, host %r" % (thread_id(), host))


### PR DESCRIPTION
Mirrors which have failed to be successfully crawled for a certain
number of crawls are now automatically disabled (user_active).
The reason for the automatic disabling is visible in the field
disable_reason.