### PR TITLE
Scan the directories which are supposed to be on each mirror.

### DIFF
--- a/utility/mm2_crawler
+++ b/utility/mm2_crawler
@@ -739,7 +739,6 @@ def try_per_category(
         return False
     # for all directories in this category
     for d in trydirs:
-        d = d.directory
         # Check if maximum crawl time for this host has been reached
         timeout_check(timeout)
 
@@ -999,7 +998,7 @@ def per_host(session, host, options, config):
         # which is accessible via http or ftp
         successful_categories += 1
 
-        trydirs = list(hc.directories)
+        trydirs = list(hc.category.directories)
         # check the complete category in one go with rsync
         try:
             has_all_files = try_per_category(
@@ -1023,8 +1022,6 @@ def per_host(session, host, options, config):
         try_later_delay = 1
         for d in trydirs:
             timeout_check(options.timeout_minutes)
-
-            d = d.directory
 
             if not d.readable:
                 continue


### PR DESCRIPTION
The crawler was only looking at the files which a mirror actually
had and not at the files it is supposed to have. This lead to the
situation that a newly added host or category was never crawled
successfully. Now the crawler checks the list of files which are
supposed to be on the host and compares it with the actual content
of the crawled mirror.