### PR TITLE
Umdl log and category fixes

### DIFF
--- a/mirrormanager2/default_config.py
+++ b/mirrormanager2/default_config.py
@@ -78,6 +78,13 @@ MM_COOKIE_REQUIRES_HTTPS = True
 # Default: ``.MirrorManager``.
 MM_COOKIE_NAME = 'MirrorManager'
 
+# If this variable is set (and the directory exists) the crawler
+# will create per host log files in MM_LOG_DIR/crawler/<hostid>.log
+# which can the be used in the web interface by the mirror admins.
+# Other parts besides the crawler are also using this variable to
+# decide where to store log files.
+MM_LOG_DIR = '/var/log/mirrormanager'
+
 # If not specified the application will rely on the root_url when sending
 # emails, otherwise it will use this URL
 # Default: ``None``.
@@ -94,11 +101,6 @@ CHECK_SESSION_IP = True
 # Depending on the setup and the crawler frequency rsync's timeout option
 # can be used decrease the probability of stale rsync processes
 CRAWLER_RSYNC_PARAMETERS = '--no-motd --timeout 14400'
-
-# If this variable is set (and the directory exists)
-# the crawler will create per host log files with <hostid>.log
-# which can the be used in the web interface by the mirror admins
-CRAWLER_LOG_DIR = '/var/log/mirrormanager/crawler'
 
 # If a host fails for CRAWLER_AUTO_DISABLE times in a row
 # the host will be disable automatically (user_active)

--- a/utility/mirrormanager2.cfg.sample
+++ b/utility/mirrormanager2.cfg.sample
@@ -74,6 +74,13 @@ MM_COOKIE_REQUIRES_HTTPS = True
 # Default: ``.MirrorManager``.
 MM_COOKIE_NAME = 'MirrorManager'
 
+# If this variable is set (and the directory exists) the crawler
+# will create per host log files in MM_LOG_DIR/crawler/<hostid>.log
+# which can the be used in the web interface by the mirror admins.
+# Other parts besides the crawler are also using this variable to
+# decide where to store log files.
+MM_LOG_DIR = '/var/log/mirrormanager'
+
 # If not specified the application will rely on the root_url when sending
 # emails, otherwise it will use this URL
 # Default: ``None``.
@@ -97,11 +104,6 @@ CRAWLER_SEND_EMAIL =  True
 # Specify additional rsync parameters for the crawler
 # --timeout 14400: abort rsync crawl after 4 hours
 CRAWLER_RSYNC_PARAMETERS = '--no-motd --timeout 14400'
-
-# If this variable is set (and the directory exists)
-# the crawler will create per host log files with <hostid>.log
-# which can the be used in the web interface by the mirror admins
-CRAWLER_LOG_DIR = '/var/log/mirrormanager/crawler'
 
 # If a host fails for CRAWLER_AUTO_DISABLE times in a row
 # the host will be disable automatically (user_active)

--- a/utility/mirrormanager2.spec
+++ b/utility/mirrormanager2.spec
@@ -167,6 +167,10 @@ install -m 644 utility/mirrormanager2.cfg.sample \
 install -m 644 utility/mm2_crawler.logrotate \
     $RPM_BUILD_ROOT/%{_sysconfdir}/logrotate.d/mm2_crawler
 
+# Install umdl logrotate definition
+install -m 644 utility/mm2_umdl.logrotate \
+    $RPM_BUILD_ROOT/%{_sysconfdir}/logrotate.d/mm2_umdl
+
 # Install WSGI file
 install -m 644 utility/mirrormanager2.wsgi \
     $RPM_BUILD_ROOT/%{_datadir}/mirrormanager2/mirrormanager2.wsgi
@@ -261,6 +265,7 @@ exit 0
 
 
 %files backend
+%config(noreplace) %{_sysconfdir}/logrotate.d/mm2_umdl
 %attr(755,mirrormanager,mirrormanager) %dir %{_localstatedir}/lock/mirrormanager
 %attr(755,mirrormanager,mirrormanager) %dir %{_localstatedir}/lib/mirrormanager
 %{_datadir}/mirrormanager2/zebra-dump-parser/

--- a/utility/mm2_crawler
+++ b/utility/mm2_crawler
@@ -1124,11 +1124,12 @@ def worker(options, config, host_id):
     threadlocal.hostname = host.name
 
     # setup per thread file logger
-    log_dir = config.get('CRAWLER_LOG_DIR', None)
+    log_dir = config.get('MM_LOG_DIR', None)
     # check if the directory exists
     if log_dir is not None:
+        log_dir += "/crawler"
         if not os.path.isdir(log_dir):
-            # CRAWLER_LOG_DIR seems to be configured but does not exist
+            # MM_LOG_DIR/crawler seems to be configured but does not exist
             # not logging
             logger.warning("Directory " + log_dir + " does not exists."
                            " Not logging per host")

--- a/utility/mm2_umdl.logrotate
+++ b/utility/mm2_umdl.logrotate
@@ -1,0 +1,9 @@
+/var/log/mirrormanager/umdl.log {
+    missingok
+    notifempty
+    daily
+    dateext
+    rotate 15
+    postrotate
+    endscript
+}

--- a/utility/mm2_update-master-directory-list
+++ b/utility/mm2_update-master-directory-list
@@ -724,40 +724,8 @@ def sync_directories_from_disk(
     sync_category_directories(
         session, config, diskpath, category, category_directories)
 
-
-def main():
-    global delete_directories
+def setup_logging(config, options):
     global logger
-    parser = optparse.OptionParser(usage=sys.argv[0] + " [options]")
-    parser.add_option(
-        "-c", "--config",
-        dest="config", default='/etc/mirrormanager/mirrormanager2.cfg',
-        help="Configuration file to use")
-    parser.add_option(
-        "--logfile",
-        dest="logfile", default='umdl.log',
-        metavar="FILE", help="write logs to FILE")
-    parser.add_option(
-        "--debug",
-        dest="debug", default=False, action="store_true",
-        help="enable debugging")
-    parser.add_option(
-        "--delete-directories",
-        dest="delete_directories",
-        default=delete_directories,
-        action="store_true",
-        help="delete directories from the database that are no longer "
-            "on disk")
-
-    (options, args) = parser.parse_args()
-    config = dict()
-    with open(options.config) as config_file:
-        exec(compile(config_file.read(), options.config, 'exec'), config)
-
-    session = mirrormanager2.lib.create_session(config['DB_URL'])
-
-    delete_directories = options.delete_directories
-
     log_dir = config.get('MM_LOG_DIR', None)
     # check if the directory exists
     if log_dir is not None:
@@ -780,7 +748,9 @@ def main():
     handler = logging.handlers.WatchedFileHandler(log_file, "a+b")
     handler.setFormatter(formatter)
     logger.addHandler(handler)
-    if options.debug:
+    # list_categories is a special case where the user wants to see something
+    # on the console and not only in the log file
+    if options.debug or options.list_categories:
         sh = logging.StreamHandler()
         sh.setFormatter(formatter)
         logger.addHandler(sh)
@@ -788,9 +758,70 @@ def main():
     else:
         logger.setLevel(logging.INFO)
 
+
+def main():
+    global delete_directories
+    global logger
+    parser = optparse.OptionParser(usage=sys.argv[0] + " [options]")
+    parser.add_option(
+        "-c", "--config",
+        dest="config", default='/etc/mirrormanager/mirrormanager2.cfg',
+        help="Configuration file to use")
+    parser.add_option(
+        "--logfile",
+        dest="logfile", default='umdl.log',
+        metavar="FILE", help="write logs to FILE")
+    parser.add_option(
+        "--list",
+        dest="list_categories", default=False, action="store_true",
+        help="list existing categories and exit")
+    parser.add_option(
+        "--category", metavar="CATEGORY",
+        dest="categories", default=None,
+        help="only scan category CATEGORY")
+    parser.add_option(
+        "--debug",
+        dest="debug", default=False, action="store_true",
+        help="enable debugging")
+    parser.add_option(
+        "--delete-directories",
+        dest="delete_directories",
+        default=delete_directories,
+        action="store_true",
+        help="delete directories from the database that are no longer "
+            "on disk")
+
+    (options, args) = parser.parse_args()
+    config = dict()
+    with open(options.config) as config_file:
+        exec(compile(config_file.read(), options.config, 'exec'), config)
+
+    session = mirrormanager2.lib.create_session(config['DB_URL'])
+
+    delete_directories = options.delete_directories
+
+    setup_logging(config, options)
+
     logger.info("Starting umdl")
+
+    if options.list_categories:
+        categories = mirrormanager2.lib.get_categories(session)
+        for c in categories:
+            logger.info(c)
+        session.close()
+        logger.info("Ending umdl")
+        return 0
+
     setup_arch_version_cache(session)
-    for i in config.get('umdl_master_directories'):
+    check_categories = []
+    if options.categories is None:
+        check_categories = config.get('umdl_master_directories')
+    else:
+        for i in config.get('umdl_master_directories'):
+            if i['category'] == options.categories:
+                check_categories.append(i)
+
+    for i in check_categories:
         cname = i['category']
 
         category = mirrormanager2.lib.get_category_by_name(session, cname)

--- a/utility/mm2_update-master-directory-list
+++ b/utility/mm2_update-master-directory-list
@@ -758,15 +758,35 @@ def main():
 
     delete_directories = options.delete_directories
 
+    log_dir = config.get('MM_LOG_DIR', None)
+    # check if the directory exists
+    if log_dir is not None:
+        if not os.path.isdir(log_dir):
+            # MM_LOG_DIR seems to be configured but does not exist
+            # Logging into cwd.
+            logger.warning("Directory " + log_dir + " does not exists."
+                           " Logging into CWD.")
+            log_dir = None
+
+    if log_dir is not None:
+        log_file = log_dir + "/" + options.logfile
+    else:
+        log_file = options.logfile
+
     fmt = '%(asctime)s %(message)s'
     datefmt = '%m/%d/%Y %I:%M:%S %p'
     formatter = logging.Formatter(fmt=fmt, datefmt=datefmt)
     logger = logging.getLogger('umdl')
-    handler = logging.handlers.WatchedFileHandler(options.logfile, "a+b")
+    handler = logging.handlers.WatchedFileHandler(log_file, "a+b")
     handler.setFormatter(formatter)
     logger.addHandler(handler)
     if options.debug:
+        sh = logging.StreamHandler()
+        sh.setFormatter(formatter)
+        logger.addHandler(sh)
         logger.setLevel(logging.DEBUG)
+    else:
+        logger.setLevel(logging.INFO)
 
     logger.info("Starting umdl")
     setup_arch_version_cache(session)


### PR DESCRIPTION
These two commits try to fix logging to umdl.log and where that file should be and also introduces the possibility to only scan a single category. This opens up the possibility to start a category specific scan upon fedmsg notifications and not run a scan over the whole tree every two hours.
