### PR TITLE
[RFC] Trying explicit garbage collection

### DIFF
--- a/utility/mm2_crawler
+++ b/utility/mm2_crawler
@@ -16,6 +16,7 @@ import threading
 import time
 import urllib2
 import urlparse
+import gc
 
 sys.path.append('..')
 import mirrormanager2.lib
@@ -1182,6 +1183,7 @@ def worker(options, config, host_id):
     fh.close()
     session.close()
     threads_active = threads_active - 1
+    gc.collect()
     return rc
 
 


### PR DESCRIPTION
The crawler requires a lot of memory. With the explicit garbage
collection at the end of each crawler thread the crawler has not
been OOM killed for the last 4 runs. If this actually helps is
not very clear but it seems to slightly decrease the OOM killed
frequency. Unfortunately it seems difficult to tell which part
of the crawler and which thread is using the memory and for what.