### PR TITLE
Do not only create /var/lock/mirrormanager on installation.

### DIFF
--- a/utility/backend_tempfile.conf
+++ b/utility/backend_tempfile.conf
@@ -1,1 +1,2 @@
 d /var/run/mirrormanager 0775 mirrormanager mirrormanager
+d /var/lock/mirrormanager 0775 mirrormanager mirrormanager


### PR DESCRIPTION
So that /var/lock/mirrormanager is created on every reboot it also needs
to be included in tmpfiles.d.