### PR TITLE
Support always update hosts which are unreachable.

### DIFF
--- a/utility/mm2_crawler
+++ b/utility/mm2_crawler
@@ -978,6 +978,7 @@ def per_host(session, host, options, config):
 
     for hc in host_categories_to_scan:
         if hc.always_up2date:
+            successful_categories += 1
             continue
         category = hc.category
 


### PR DESCRIPTION
The crawler was not able to reach dl.fedoraproject.org due to
firewalls and has therefore disabled the master mirror. Now all
categories which are marked as always up to date count as a
successfully scanned category and are not auto-disabled after a
short time.