### PR TITLE
Umdl delete

### DIFF
--- a/mirrormanager2/lib/model.py
+++ b/mirrormanager2/lib/model.py
@@ -475,7 +475,7 @@ class HostCategory(BASE):
     id = sa.Column(sa.Integer, primary_key=True)
     host_id = sa.Column(sa.Integer, sa.ForeignKey('host.id'), nullable=True)
     category_id = sa.Column(
-        sa.Integer, sa.ForeignKey('category.id'), nullable=True)
+        sa.Integer, sa.ForeignKey('category.id', ondelete='CASCADE'), nullable=True)
     always_up2date = sa.Column(sa.Boolean(), default=False, nullable=False)
 
     # Relations
@@ -521,7 +521,7 @@ class HostCategoryDir(BASE):
     up2date = sa.Column(
         sa.Boolean, default=True, nullable=False, index=True)
     directory_id = sa.Column(
-        sa.Integer, sa.ForeignKey('directory.id'), nullable=True)
+        sa.Integer, sa.ForeignKey('directory.id', ondelete='CASCADE'), nullable=True)
 
     # Relations
     directory = relation(
@@ -565,7 +565,7 @@ class CategoryDirectory(BASE):
     directory = relation(
         'Directory',
         foreign_keys=[directory_id], remote_side=[Directory.id],
-        backref=backref('categorydir')
+        backref=backref('categorydir', cascade="delete, delete-orphan", single_parent=True)
     )
 
     def __repr__(self):
@@ -836,7 +836,8 @@ class FileDetail(BASE):
     directory = relation(
         'Directory',
         foreign_keys=[directory_id], remote_side=[Directory.id],
-        backref="fileDetails",
+        backref=backref( 'fileDetails', cascade="delete, delete-orphan",
+                  single_parent=True)
     )
 
 

--- a/utility/mm2_update-master-directory-list
+++ b/utility/mm2_update-master-directory-list
@@ -398,7 +398,7 @@ def is_excluded(path, excludes):
     return False
 
 
-def nuke_gone_directories(diskpath, category):
+def nuke_gone_directories(session, diskpath, category):
     """ deleting a Directory has a ripple effect through the whole
         database.  Be really sure you're ready do to this.  It comes
         in handy when say a Test release is dropped."""
@@ -413,7 +413,8 @@ def nuke_gone_directories(diskpath, category):
         if not os.path.isdir(os.path.join(diskpath, relativeDName)):
             if len(d.categories) == 1: # safety, this should always trigger
                 logger.info("Deleting gone directory %s" % (d.name))
-                d.destroySelf()
+                session.delete(d)
+                session.commit()
 
 
 def ctime_from_rsync(date, hms):
@@ -850,7 +851,7 @@ def main():
             sync_directories_from_disk(session, config, i['path'], category)
 
             if options.delete_directories:
-                nuke_gone_directories(i['path'], category)
+                nuke_gone_directories(session, i['path'], category)
 
     logger.info("Ending umdl")
 


### PR DESCRIPTION
I am not sure this 100% correct, but this are the minimal changes to make umdl's delete option work again. Running umdl with --delete in Fedora's MM staging instance reduces the size of a database dump from 800MB to 760MB.