### PR TITLE
If the user is not an admin, keep the existing admin_active settings

### DIFF
--- a/mirrormanager2/app.py
+++ b/mirrormanager2/app.py
@@ -335,7 +335,12 @@ def site_view(site_id):
 
     form = forms.AddSiteForm(obj=siteobj)
     if form.validate_on_submit():
+        admin_active = siteobj.admin_active
         obj = form.populate_obj(obj=siteobj)
+
+        # If the user is *not* an admin, keep the current admin_active flag
+        if not is_mirrormanager_admin(flask.g.fas_user):
+            siteobj.admin_active = admin_active
 
         try:
             SESSION.flush()
@@ -587,9 +592,15 @@ def host_view(host_id):
 
     form = forms.AddHostForm(obj=hostobj)
     if form.validate_on_submit():
+        admin_active = hostobj.admin_active
         form.populate_obj(obj=hostobj)
         hostobj.bandwidth_int = int(hostobj.bandwidth_int)
         hostobj.asn = None if not hostobj.asn else int(hostobj.asn)
+
+        # If the user is *not* an admin, keep the current admin_active flag
+        if not is_mirrormanager_admin(flask.g.fas_user):
+            hostobj.admin_active = admin_active
+
         message = dict(
             site_id=hostobj.site_id,
             host_id=host_id,

--- a/mirrormanager2/templates/fedora/host_new.html
+++ b/mirrormanager2/templates/fedora/host_new.html
@@ -15,7 +15,7 @@
 <form action="" method="POST">
   <table>
     {{ render_field_in_row(form.name) }}
-    {{ render_field_in_row(form.admin_active) }}
+    {% if is_admin %}{{ render_field_in_row(form.admin_active) }}{% endif %}
     {{ render_field_in_row(form.user_active) }}
     {{ render_field_in_row(form.country) }}
     {{ render_field_in_row(form.bandwidth_int) }}

--- a/mirrormanager2/templates/fedora/site_new.html
+++ b/mirrormanager2/templates/fedora/site_new.html
@@ -38,7 +38,7 @@
     {{ render_field_in_row(form.password) }}
     {{ render_field_in_row(form.org_url) }}
     {{ render_field_in_row(form.private) }}
-    {{ render_field_in_row(form.admin_active) }}
+    {% if is_admin %}{{ render_field_in_row(form.admin_active) }}{% endif %}
     {{ render_field_in_row(form.user_active) }}
     {{ render_field_in_row(form.all_sites_can_pull_from_me) }}
     {{ render_field_in_row(form.downstream_comments) }}


### PR DESCRIPTION
Boolean in html are processed in such a way that: present=1 and absent=0
so by hiding the admin_active box to non-admins, we are sending an 'absent'
signal and thus if we do not handle this, we end-up with changing
involuntarily the admin_active flag.