### PR TITLE
Remove all whitespaces around the mirror URLs

### DIFF
--- a/mirrormanager2/app.py
+++ b/mirrormanager2/app.py
@@ -1145,6 +1145,7 @@ def host_category_url_new(host_id, hc_id):
         host_category_u = model.HostCategoryUrl()
         host_category_u.host_category_id = hcobj.id
         form.populate_obj(obj=host_category_u)
+        host_category_u.url = form.url.data.strip()
         SESSION.add(host_category_u)
 
         try:

--- a/utility/mm2_crawler
+++ b/utility/mm2_crawler
@@ -1183,7 +1183,7 @@ def per_host(session, host, options, config):
             continue
         category = hc.category
 
-        host_category_urls = [hcurl.url for hcurl in hc.urls]
+        host_category_urls = [hcurl.url.strip() for hcurl in hc.urls]
         categoryUrl = method_pref(host_category_urls)
         if categoryUrl is None:
             continue


### PR DESCRIPTION
Some mirrors where failing to be scanned as a leading whitespace broke
our protocol detection (.startswith('rsync')). This ignores whitespace
in the URLs.