### PR TITLE
Sort metalinks alternates by timestamps descending

### DIFF
--- a/mirrormanager2/lib/mirrorlist.py
+++ b/mirrormanager2/lib/mirrorlist.py
@@ -23,6 +23,8 @@ import os
 import hashlib
 import cPickle as pickle
 
+from operator import itemgetter
+
 from IPy import IP
 import pprint
 import dns.resolver
@@ -300,6 +302,15 @@ def file_details_cache(session):
                     sha512=fd.sha512,
                     size=fd.size)
                 append_value_to_cache(cache[d.name], fd.filename, details)
+
+    for dir in cache.keys():
+        for file in cache[dir].keys():
+            if len(cache[dir][file]) > 1:
+                cache[dir][file] = sorted(
+                    cache[dir][file],
+                    key=itemgetter('timestamp'),
+                    reverse=True)
+
     return cache
 
 


### PR DESCRIPTION
Another try to sort the alternates in the metalink by timestamps in descending order. This time the list is sorted during pkl generation.

https://mirrors.stg.fedoraproject.org/metalink?repo=rawhide&arch=x86_64

Solves #117