### PR TITLE
Add code to graph repomd.xml propagation

### DIFF
--- a/utility/mm2_crawler
+++ b/utility/mm2_crawler
@@ -34,6 +34,7 @@ all_hosts = 0
 threads = 0
 threads_active = 0
 hosts_failed = 0
+check_start = time.strftime("%Y-%m-%d-%H-%M-%S", time.gmtime())
 
 # This is the global timeout variable, so that it can be
 # decreased by the signal handler and thus change in all threads.
@@ -315,6 +316,18 @@ def main():
     parser.add_argument(
         "--debug", "-d", dest="debug", action="store_true", default=False,
         help="enable printing of debug-level messages")
+
+    parser.add_argument(
+        "--propagation", "-p", dest="propagation", action="store_true", default=False,
+        help="Print out information about repomd.xml propagation "
+            "Defaults to development/rawhide/x86_64/os/repodata "
+            "Only the category 'Fedora Linux' is supported")
+
+    parser.add_argument(
+        "--proppath", dest="proppath", metavar='PATH',
+        default="development/rawhide/x86_64/os/repodata",
+        help="Use another path for propgation check  "
+            "Defaults to development/rawhide/x86_64/os/repodata")
 
     options = parser.parse_args()
 
@@ -1134,6 +1147,38 @@ def check_continent(categoryUrl):
     return 8
 
 
+def check_propagation(session, catname, host_category_urls, path):
+    # Print out information about the repomd.xml status
+    if catname != 'Fedora Linux':
+        return 9
+    # Right now propagation test mode only supports the category "Fedora Linux"
+    base = "pub/fedora/linux/" + path
+    url = None
+    for u in host_category_urls:
+        if not u.endswith('/'):
+            u += '/'
+        if u.startswith('http:'):
+            url = u
+    if not url:
+        return 9
+    d = mirrormanager2.lib.get_directory_by_name(session, base)
+    fd = mirrormanager2.lib.get_file_detail(session, 'repomd.xml', d.id, reverse=True)
+    url += path
+    url += '/repomd.xml'
+    import requests
+    ses = requests.Session()
+    try:
+        contents = ses.get(url, timeout=30)
+    except requests.exceptions.ConnectionError:
+        logger.info("URL::%s::SHA256::%s::%s::%s" % (url, 'NOSUM', check_start, fd.sha256))
+        return 9
+    has = hashlib.sha256()
+    has.update(contents.content)
+    csum = has.hexdigest()
+    logger.info("URL::%s::SHA256::%s::%s::%s" % (url, csum, check_start, fd.sha256))
+    return 9
+
+
 def per_host(session, host, options, config):
     """ This function scans all categories a host has defined.
     If a RSYNC URL is available it tries to scan the host requiring
@@ -1178,12 +1223,17 @@ def per_host(session, host, options, config):
 
     for hc in host_categories_to_scan:
         timeout_check()
-        if hc.always_up2date:
+        if hc.always_up2date and not options.propagation:
             successful_categories += 1
             continue
         category = hc.category
 
-        host_category_urls = [hcurl.url.strip() for hcurl in hc.urls]
+        host_category_urls = [hcurl.url for hcurl in hc.urls]
+
+        if options.propagation:
+            return check_propagation(session, category.name,
+                host_category_urls, options.proppath)
+
         categoryUrl = method_pref(host_category_urls)
         if categoryUrl is None:
             continue
@@ -1344,6 +1394,35 @@ def count_crawl_failures(host, config):
             " consecutive crawl failures" % auto_disable )
         host.user_active = False
 
+def thread_file_logger(log_dir, host_id, debug):
+
+    # check if the directory exists
+    if log_dir is not None:
+        log_dir += "/crawler"
+        if not os.path.isdir(log_dir):
+            # MM_LOG_DIR/crawler seems to be configured but does not exist
+            # not logging
+            logger.warning("Directory " + log_dir + " does not exists."
+                           " Not logging per host")
+            log_dir = None
+
+    log_file = None
+    fh = None
+    if log_dir is not None:
+        log_file = log_dir + "/" + str(host_id) + '.log'
+        fh = logging.FileHandler(log_file)
+        threadlocal.thread_id = thread_id()
+        f = InjectingFilter(thread_id())
+        fh.addFilter(f)
+
+        if debug:
+            fh.setLevel(logging.DEBUG)
+        else:
+            fh.setLevel(logging.INFO)
+        fh.setFormatter(formatter)
+        logger.addHandler(fh)
+
+    return log_file, fh
 
 def worker(options, config, host_id):
     global current_host
@@ -1364,38 +1443,25 @@ def worker(options, config, host_id):
     threadlocal.hostid = host.id
     threadlocal.hostname = host.name
 
-    # setup per thread file logger
-    log_dir = config.get('MM_LOG_DIR', None)
-    # check if the directory exists
-    if log_dir is not None:
-        log_dir += "/crawler"
-        if not os.path.isdir(log_dir):
-            # MM_LOG_DIR/crawler seems to be configured but does not exist
-            # not logging
-            logger.warning("Directory " + log_dir + " does not exists."
-                           " Not logging per host")
-            log_dir = None
-
     log_file = None
-    if log_dir is not None:
-        log_file = log_dir + "/" + str(host.id) + '.log'
-        fh = logging.FileHandler(log_file)
-        threadlocal.thread_id = thread_id()
-        f = InjectingFilter(thread_id())
-        fh.addFilter(f)
-
-        if options.debug:
-            fh.setLevel(logging.DEBUG)
-        else:
-            fh.setLevel(logging.INFO)
-        fh.setFormatter(formatter)
-        logger.addHandler(fh)
+    fh = None
+    if not options.propagation:
+        log_file, fh = thread_file_logger(config.get('MM_LOG_DIR', None),
+            host.id, options.debug)
 
     logger.info("Worker %r starting on host %r" % (thread_id(), host))
 
 
     try:
         rc = per_host(session, host.id, options, config)
+
+        # If 9 is returned the crawler is running in propagation test mode.
+        if rc == 9:
+            # Do not save any status about this run.
+            threads_active = threads_active - 1
+            session.close()
+            return 0
+
         last_crawled = datetime.datetime.utcnow()
         last_crawl_duration = time.time() -  threadlocal.starttime
         if rc == 5:
@@ -1446,8 +1512,9 @@ def worker(options, config, host_id):
         rc = 3
 
     logger.info("Ending crawl of %r with status %r" % (host, rc))
-    logger.removeHandler(fh)
-    fh.close()
+    if fh:
+        logger.removeHandler(fh)
+        fh.close()
     session.close()
     threads_active = threads_active - 1
     gc.collect()

--- a/utility/mm2_propagation
+++ b/utility/mm2_propagation
@@ -1,0 +1,207 @@
+#!/usr/bin/python
+
+import numpy as np
+import matplotlib.pyplot as plt
+import os
+import sys
+import time
+import glob
+
+from matplotlib import rc
+
+font = {'family' : 'serif',
+        'size'   : 10}
+
+rc('text', usetex=True)
+rc('font', **font)
+
+def list_adder(a, b):
+    return [i+j for i,j in zip(a, b)]
+
+def label_bars_size(rects, fmt, offset=[]):
+    i = 0
+    for rect in rects:
+        width = int(rect.get_width())
+
+        xloc = rect.get_x()+rect.get_width()/2.0
+        try:
+            plus = offset[i]
+        except:
+            plus = 0
+
+        if rect.get_height() > 8:
+            yloc = rect.get_height() / 2 + plus + 3
+        else:
+            yloc = rect.get_height() + plus - 1.2
+
+        if rect.get_height() > 6:
+            ax.text(xloc, yloc, fmt % rect.get_height(), horizontalalignment='center', rotation='horizontal',
+                verticalalignment='top', color='white')
+        i += 1
+
+
+repomd_same = []
+repomd_one_day = []
+repomd_two_day = []
+repomd_other = []
+repomd_none = []
+labels = []
+maximum = 0
+sha256sums = []
+
+hosts_broken = {}
+hosts_older = {}
+hosts_older_1 = {}
+hosts_older_2 = {}
+
+prefix = ""
+if len(sys.argv) == 2:
+    prefix = sys.argv[1]
+
+files = 'propagation/%sprop*' % prefix
+
+total = len(glob.glob(files))
+remaining = total
+print "%d data points available" % total
+
+
+
+for filename in sorted(glob.glob(files)):
+    for line in open(filename):
+        line = line.rstrip()
+        line = line.split('::')
+        if not line[5] in sha256sums:
+            sha256sums.append(line[5])
+
+for filename in sorted(glob.glob(files)):
+    total -= 1
+    if total > 58:
+        remaining -=1
+        continue
+    if remaining > 30 and total % 2 == 0:
+        continue
+    remaining -= 1
+    same = 0
+    one_day = 0
+    two_day = 0
+    other = 0
+    none = 0
+    scandate = None
+
+    for line in open(filename):
+        line = line.rstrip()
+        line = line.split('::')
+        date = line[4].split('-')
+        scandate = "%s-%s-%s\n%s-%s-%s" % tuple(date)
+        if line[3] == 'NOSUM':
+            none += 1
+            try:
+                hosts_broken[line[1]] += 1
+            except:
+                hosts_broken[line[1]] = 1
+
+        elif line[3] == line[5]:
+            same += 1
+        elif line[3] in sha256sums:
+            offset = sha256sums.index(line[5])
+            if sha256sums.index(line[3]) == offset:
+                same += 1
+            elif sha256sums.index(line[3]) == offset - 1:
+                one_day += 1
+                try:
+                    hosts_older_1[line[1]] += 1
+                except:
+                    hosts_older_1[line[1]] = 1
+            elif sha256sums.index(line[3]) == offset - 2:
+                two_day += 1
+                try:
+                    hosts_older_2[line[1]] += 1
+                except:
+                    hosts_older_2[line[1]] = 1
+            else:
+                other += 1
+        else:
+            other += 1
+            try:
+                hosts_older[line[1]] += 1
+            except:
+                hosts_older[line[1]] = 1
+    if none + same + other + one_day + two_day > maximum:
+        maximum = none + same + other + one_day + two_day
+
+    repomd_same.append(same)
+    repomd_one_day.append(one_day)
+    repomd_two_day.append(two_day)
+    repomd_other.append(other)
+    repomd_none.append(none)
+    labels.append(scandate)
+
+print "%d data points used" %  len(repomd_same)
+
+fd = open('%srepomd-report.txt' % prefix, 'w')
+
+print "Hosts broken"
+fd.write("Hosts broken\n")
+for url, count in sorted(hosts_broken.items(), key=lambda x: (int(x[1])), reverse=True):
+    print "%s: %d" % (url, count)
+    fd.write("%s: %d\n" % (url, count))
+print "Hosts older"
+fd.write("Hosts older\n")
+for url, count in sorted(hosts_older.items(), key=lambda x: (int(x[1])), reverse=True):
+    print "%s: %d" % (url, count)
+    fd.write("%s: %d\n" % (url, count))
+print "Hosts older - 1"
+fd.write("Hosts older - 1\n")
+for url, count in sorted(hosts_older_1.items(), key=lambda x: (int(x[1])), reverse=True):
+    print "%s: %d" % (url, count)
+    fd.write("%s: %d\n" % (url, count))
+fd.write("Hosts older - 2\n")
+print "Hosts older - 2"
+for url, count in sorted(hosts_older_2.items(), key=lambda x: (int(x[1])), reverse=True):
+    print "%s: %d" % (url, count)
+    fd.write("%s: %d\n" % (url, count))
+
+fd.close()
+
+ind = np.arange(len(labels))
+width = 0.62
+
+fig = plt.figure(figsize=(16, 8))
+ax = fig.add_subplot(111)
+
+rects = ax.bar(ind, repomd_same, width, color='red', label="synced")
+label_bars_size(rects, '%.0f')
+
+rects = ax.bar(ind, repomd_one_day, width, bottom=repomd_same,
+        color='mediumvioletred',
+        label='synced - 1')
+label_bars_size(rects, '%.0f', repomd_same)
+
+bottom = list_adder(repomd_same, repomd_one_day)
+rects = ax.bar(ind, repomd_two_day, width, bottom=bottom, color='b',
+        label='synced - 2')
+label_bars_size(rects, '%.0f', bottom)
+
+bottom = list_adder(bottom, repomd_two_day)
+rects = ax.bar(ind, repomd_other, width, bottom=bottom, color='g', label='older')
+label_bars_size(rects, '%.0f', bottom)
+
+bottom = list_adder(bottom, repomd_other)
+rects = ax.bar(ind, repomd_none, width, bottom=bottom, color='y', label='N/A')
+label_bars_size(rects, '%.0f', bottom)
+
+ax.set_ylim(0, maximum +40)
+ax.set_xticks(ind+width)
+ax.set_xticklabels(labels)
+plt.setp(plt.xticks()[1], rotation=90)
+
+plt.legend(loc=2, shadow=True, fancybox=True, ncol=3)
+if prefix == 'f22-updates-':
+    plt.title("repomd.xml propagation for updates/22/x86 64/repodata")
+else:
+    plt.title("repomd.xml propagation for development/rawhide/x86 64/os/repodata")
+plt.savefig("%s%s-repomd-propagation.pdf" % (prefix,labels[len(labels)-1].replace('\n','-')), bbox_inches='tight')
+plt.savefig("%s%s-repomd-propagation.svg" % (prefix,labels[len(labels)-1].replace('\n','-')), bbox_inches='tight')
+print "%s%s-repomd-propagation.pdf" % (prefix,labels[len(labels)-1].replace('\n','-'))
+plt.savefig("%srepomd-propagation.pdf" % prefix , bbox_inches='tight')
+plt.savefig("%srepomd-propagation.svg" % prefix , bbox_inches='tight')


### PR DESCRIPTION
The crawler has been extended to only retrieve the repomd.xml file and print out its sha256sum. To create diagrams of this output an additional script has been added. The script to create the diagrams has a few hard-coded assumptions coded into it which is not perfect but integrating it into mirrormanager2's repository makes sure the script is not lost.