### PR TITLE
Deleting URLs if site or host is removed.

### DIFF
--- a/mirrormanager2/lib/model.py
+++ b/mirrormanager2/lib/model.py
@@ -490,7 +490,9 @@ class HostCategory(BASE):
     host = relation(
         'Host',
         foreign_keys=[host_id], remote_side=[Host.id],
-        backref=backref('categories')
+        backref=backref(
+            'categories', cascade="delete, delete-orphan",
+            single_parent=True)
     )
 
     # Constraints


### PR DESCRIPTION
Deleting a mirror site and/or host did not correctly delete the URLs:

https://github.com/fedora-infra/mirrormanager2/issues/115
https://fedorahosted.org/mirrormanager/ticket/61

As URLs can only exist once in the database the URLs with the deleted
site and/or hosts are still in the database and cannot be added to
another host or deleted. Right now these left-over URLs have to be
deleted manually.

Signed-off-by: Adrian Reber <adrian@lisas.de>