### PR TITLE
Really ensure that new host is admin_active

### DIFF
--- a/mirrormanager2/app.py
+++ b/mirrormanager2/app.py
@@ -426,8 +426,8 @@ def host_new(site_id):
         host = model.Host()
         SESSION.add(host)
         host.site_id = siteobj.id
-        host.admin_active = True
         form.populate_obj(obj=host)
+        host.admin_active = True
 
         host.bandwidth_int = int(host.bandwidth_int)
         host.asn = None if not host.asn else int(host.asn)


### PR DESCRIPTION
f59f7455 has a bug, setting host.admin_active = True before
form.populate_obj() which immediately sets it to false again
for non-admin users.

Switch those lines.