### PR TITLE
Switch the MirrorList server to use threading rather than forking

### DIFF
--- a/mirrorlist/mirrorlist_server.py
+++ b/mirrorlist/mirrorlist_server.py
@@ -196,18 +196,13 @@ def metalink(cache, directory, file, hosts_and_urls):
 
 
 def tree_lookup(tree, ip, field, maxResults=None):
-    # fast lookup in the tree; if present, find all the matching values by
-    # deleting the found one and searching again this is safe w/o copying
-    # the tree again only because this is the only place the tree is used,
-    # and we'll get a new copy of the tree from our parent the next time it
-    # fork()s.
+    # Lookup up to maxResults matching prefixes from the tree
     # returns a list of tuples (prefix, data)
     result = []
     len_data = 0
     if ip is None:
         return result
-    node = tree.search_best(ip.strNormal())
-    while node is not None:
+    for node in tree.search_covering(ip.strNormal()):
         prefix = node.prefix
         if type(node.data[field]) == list:
             len_data += len(node.data[field])
@@ -215,10 +210,7 @@ def tree_lookup(tree, ip, field, maxResults=None):
             len_data += 1
         t = (prefix, node.data[field],)
         result.append(t)
-        if maxResults is None or len_data < maxResults:
-            tree.delete(prefix)
-            node = tree.search_best(ip.strNormal())
-        else:
+        if maxResults is not None and len_data >= maxResults:
             break
     return result
 

--- a/requirements_mirrorlist.txt
+++ b/requirements_mirrorlist.txt
@@ -1,5 +1,5 @@
 # List of dependencies for the mirrormanager repolist server
 
 GeoIP
-py-radix
+py-radix>0.8
 webob


### PR DESCRIPTION
This improves the performance significantly for several reasons:
1. Threading uses a lot less resources than forking in general.
2. Forks have Copy-On-Write for variables. This means that at the
   moment of forking, they will just point to the parent process
   for all of the memory they stored until now, so they don't have
   to actually copy all of the bits of memory over during fork().
   The problem here though is at the moment of metalink update:
   at this moment, the variables that the master proces uses for
   the in-memory structure suddenly all change. This means that
   all of the forks that are still active at that time will have
   to copy all the previous values to make sure they do not get
   impacted by the update. (Linux-specific, I am not sure about
   other Operating Systems on this).

One possible reason I could think threads have been used rather
than forks in the past is that with forking the childs do not
get impacted at the moment of metalink update. However, since
the Operating System has cross-thread locks, this is of no
issue with regards to locking (the OS will take care of it).
The duration of these locks isn't a problem either since the
only change that happens under the lock is the swapping of one
pointer (the old value) to a new value (the just parsed value).

Signed-off-by: Patrick Uiterwijk <puiterwijk@redhat.com>