### PR TITLE
Optionally exclude certain protocols from MM

### DIFF
--- a/mirrormanager2/default_config.py
+++ b/mirrormanager2/default_config.py
@@ -85,6 +85,13 @@ MM_COOKIE_NAME = 'MirrorManager'
 # decide where to store log files.
 MM_LOG_DIR = '/var/log/mirrormanager'
 
+# This is used to exclude certain protocols to be entered
+# for host category URLs at all.
+# The following is the default for Fedora to exclude FTP based
+# mirrors to be added. Removing this confguration option
+# or setting it to '' removes any protocol restrictions.
+MM_PROTOCOL_REGEX = '^(?!ftp)(.*)$'
+
 # If not specified the application will rely on the root_url when sending
 # emails, otherwise it will use this URL
 # Default: ``None``.

--- a/mirrormanager2/forms.py
+++ b/mirrormanager2/forms.py
@@ -37,6 +37,8 @@ import re
 from flask.ext import wtf
 import wtforms
 
+from mirrormanager2.app import APP
+
 COUNTRY_REGEX = '^[a-zA-Z][a-zA-Z]$'
 
 
@@ -233,9 +235,19 @@ class EditHostCategoryForm(wtf.Form):
 
 class AddHostCategoryUrlForm(wtf.Form):
     """ Form to add a host_category_url. """
+    p = APP.config.get('MM_PROTOCOL_REGEX', '')
     url = wtforms.TextField(
         'URL  <span class="error">*</span>',
-        [wtforms.validators.Required()]
+        [
+            wtforms.validators.Required(),
+            # private mirrors might have unusual URLs
+            wtforms.validators.URL(require_tld=False),
+            wtforms.validators.Regexp(
+                p,
+                flags=re.IGNORECASE,
+                message=u'Unsupported URL'
+            ),
+        ]
     )
     private = wtforms.BooleanField(
         'Private',

--- a/utility/mirrormanager2.cfg.sample
+++ b/utility/mirrormanager2.cfg.sample
@@ -81,6 +81,13 @@ MM_COOKIE_NAME = 'MirrorManager'
 # decide where to store log files.
 MM_LOG_DIR = '/var/log/mirrormanager'
 
+# This is used to exclude certain protocols to be entered
+# for host category URLs at all.
+# The following is the default for Fedora to exclude FTP based
+# mirrors to be added. Removing this confguration option
+# or setting it to '' removes any protocol restrictions.
+MM_PROTOCOL_REGEX = '^(?!ftp)(.*)$'
+
 # If not specified the application will rely on the root_url when sending
 # emails, otherwise it will use this URL
 # Default: ``None``.


### PR DESCRIPTION
This change adds the possibility to exclude certain
protocols to be entered in MirrorManager. The default
value in the configuration file of

 MM_PROTOCOL_REGEX = '^(?!ftp)(.*)$'

will prohibit that FTP based URLs are entered at all.

The goal (as discussed in #99) is to remove FTP URLs from Fedora's
MirrorManager setup.

Signed-off-by: Adrian Reber <adrian@lisas.de>