### PR TITLE
statistics: Fix various matplotlib problems

### DIFF
--- a/mirrorlist/mirrorlist_statistics
+++ b/mirrorlist/mirrorlist_statistics
@@ -23,7 +23,9 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 import sys
-import pylab
+import matplotlib
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt
 import time
 import gzip
 import getopt
@@ -152,8 +154,8 @@ for line in gzip.open(logfile):
 
 
 def do_pie(prefix, dict, accesses):
-    pylab.figure(1, figsize=(8, 8))
-    ax = pylab.axes([0.1, 0.1, 0.8, 0.8])
+    plt.figure(1, figsize=(8, 8))
+    ax = plt.axes([0.1, 0.1, 0.8, 0.8])
 
     labels = []
     fracs = []
@@ -181,14 +183,14 @@ def do_pie(prefix, dict, accesses):
         labels.append('other')
         fracs.append(rest)
 
-    pylab.pie(
+    plt.pie(
         fracs,
         labels=labels,
         autopct='%1.1f%%',
         pctdistance=0.75,
         shadow=True)
-    pylab.savefig('%s%s-%d-%02d-%02d.png' % (dest, prefix, y1, m1, d1))
-    pylab.close(1)
+    plt.savefig('%s%s-%d-%02d-%02d.png' % (dest, prefix, y1, m1, d1))
+    plt.close(1)
 
 
 def background(html, css_class, toggle):

--- a/utility/mm2_generate-worldmap
+++ b/utility/mm2_generate-worldmap
@@ -44,8 +44,8 @@ def lookup_host_locations(config):
     results = []
     tracking = []
     embargoed_countries = set(
-        [x.country_code.upper() for x in
-         list(mirrormanager2.lib.get_embargoed_countries(session))])
+        [x.upper() for x in
+         list(config['EMBARGOED_COUNTRIES'])])
 
     for hcurl in hcurls:
         hn = urlparse.urlsplit(hcurl.url)[1]

--- a/utility/mm2_propagation
+++ b/utility/mm2_propagation
@@ -23,6 +23,8 @@
 
 import argparse
 import glob
+import matplotlib
+matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 import numpy as np
 import os
@@ -31,10 +33,8 @@ import time
 
 from matplotlib import rc
 
-font = {'family': 'serif',
-        'size': 10}
+font = {'size': 9}
 
-rc('text', usetex=True)
 rc('font', **font)
 
 
@@ -73,7 +73,7 @@ def label_bars_size(rects, fmt, offset=[], last=False):
         if last:
             ax.text(
                 xloc,
-                yloc + 6,
+                rect.get_height() + plus + 6,
                 fmt %
                 float(plus + rect.get_height()),
                 horizontalalignment='center',
@@ -144,8 +144,6 @@ for filename in sorted(glob.glob(args.logfiles)):
             proppath = line[7]
         if not line[5] in sha256sums:
             sha256sums.append(line[5])
-
-proppath = proppath.replace('_', '\_')
 
 for filename in sorted(glob.glob(args.logfiles)):
     total -= 1


### PR DESCRIPTION
The matplotlib dependent scripts are trying to start a GTK interface if
no configuration file is present (like on my system) which tells that
the non-graphical interface should be used as default. With this it is
not explicitly stated in the code of the scripts that the non-graphical
version is wanted. In addition the dependency to draw the fonts with
Latex has been removed. Also switching to embargoed countries from
configuration file.

Signed-off-by: Adrian Reber <adrian@lisas.de>