### PR TITLE
Few small fixes to the emergency script

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,7 @@ setup(
         'client/report_mirror',
         'mirrorlist/mirrorlist_statistics',
         'utility/mm2_crawler',
+        'utility/mm2_emergency-expire-repo',
         'utility/mm2_generate-worldmap',
         'utility/mm2_get_global_netblocks',
         'utility/mm2_get_internet2_netblocks',

--- a/utility/mirrormanager2.spec
+++ b/utility/mirrormanager2.spec
@@ -332,6 +332,7 @@ exit 0
 %attr(755,mirrormanager,mirrormanager) %dir %{_localstatedir}/run/mirrormanager
 %{_tmpfilesdir}/%{name}-backend.conf
 %{_datadir}/mirrormanager2/zebra-dump-parser/
+%{_bindir}/mm2_emergency-expire-repo
 %{_bindir}/mm2_get_global_netblocks
 %{_bindir}/mm2_get_internet2_netblocks
 %{_bindir}/mm2_move-devel-to-release

--- a/utility/mm2_emergency-expire-repo
+++ b/utility/mm2_emergency-expire-repo
@@ -45,13 +45,9 @@ logger = logging.getLogger('mm2')
 
 def setup_logging(options):
     format = "[%(asctime)s][%(name)10s %(levelname)7s] %(message)s"
-    datefmt = '%m/%d/%Y %I:%M:%S %p'
-    logging.basicConfig(format=format, datefmt=datefmt)
+    logging.basicConfig(format=format)
 
-    if options.debug:
-        logger.setLevel(logging.DEBUG)
-    else:
-        logger.setLevel(logging.INFO)
+    logger.setLevel(logging.INFO)
 
 
 def main():
@@ -66,10 +62,6 @@ def main():
         "-c", "--config",
         dest="config", default='/etc/mirrormanager/mirrormanager2.cfg',
         help="Configuration file to use")
-    parser.add_argument(
-        "--debug",
-        dest="debug", default=False, action="store_true",
-        help="enable debugging")
 
     options = parser.parse_args()
 
@@ -100,8 +92,13 @@ def main():
     for repo in repos:
         logger.info("Clearing for repo %s" % repo.name)
         (files, deleted) = repo.emergency_expire_old_file_details(session)
-        logger.info("Files kept: %s" % ', '.join(files))
-        logger.info("Older versions deleted: " % ', '.join(deleted.keys()))
+
+        if files:
+            logger.info("Files kept: %s" % ', '.join(files))
+        if deleted.keys():
+            logger.info(
+                "Older versions deleted: %s" %
+                ', '.join(deleted.keys()))
 
     logger.info("Done.")
     return 0


### PR DESCRIPTION
I just tried the new emergency script in staging which was introduced with #154.

This PR has a few small fixes to make the script actually run and I also added it to the backend RPM as the script was not installed.

In addition to the described problems it seems not to be doing what it should do. For only one directory the script claims to have changed something:

```
[2016-01-14 08:50:36,228][       mm2    INFO] Clearing for repo pub/fedora/linux/atomic/23
[2016-01-14 08:50:36,236][       mm2    INFO] Files kept: summary
[2016-01-14 08:50:36,236][       mm2    INFO] Older versions deleted: summary
```

Everything else seems unchanged. The metalink output is also the same. The existing alternate entry is not removed. On each run the script produces the same output.

https://adrian.fedorapeople.org/mm/emergency-expire-repo-has-run
https://adrian.fedorapeople.org/mm/emergency-expire-repo-has-not-run

@puiterwijk 