### PR TITLE
get_global_netblocks: use yesterday's date

### DIFF
--- a/utility/mm2_get_global_netblocks
+++ b/utility/mm2_get_global_netblocks
@@ -37,7 +37,7 @@ function last_rib()
 
 function get_ipv6_netblocks()
 {
-    local curdate=$(date +"%Y.%m")
+    local curdate=$(date --date='yesterday' +"%Y.%m")
     URL="http://archive.routeviews.org/route-views6/bgpdata/$curdate/RIBS/"
     wget -q -O ${tmpdir}/index.html "${URL}?C=M;O=D"
     last=$(last_rib)


### PR DESCRIPTION
Fixes #165

The servers providing the IPv4/IPv6 global netblocks do not seem to be
running on UTC and therefore it can happen that when requesting the
netblock list on the first of the month on a UTC system that the
netblock list does not yet exist as the destination server is still in
the previous month. Using yesterday's date should work around/fix this.

Signed-off-by: Adrian Reber <adrian@lisas.de>