### PR TITLE
Propagation: Added path to propagation results

### DIFF
--- a/utility/mm2_crawler
+++ b/utility/mm2_crawler
@@ -1185,15 +1185,15 @@ def check_propagation(session, catname, host_category_urls, path):
         contents = ses.get(url, timeout=30)
     except requests.exceptions.ConnectionError:
         logger.info(
-            "URL::%s::SHA256::%s::%s::%s::503"
-             % (url, 'NOSUM', check_start, fd.sha256))
+            "URL::%s::SHA256::%s::%s::%s::503::%s"
+             % (url, 'NOSUM', check_start, fd.sha256, path))
         return 9
     has = hashlib.sha256()
     has.update(contents.content)
     csum = has.hexdigest()
     logger.info(
-        "URL::%s::SHA256::%s::%s::%s::%s"
-        % (url, csum, check_start, fd.sha256, contents.status_code))
+        "URL::%s::SHA256::%s::%s::%s::%s::%s"
+        % (url, csum, check_start, fd.sha256, contents.status_code, path))
     return 9
 
 


### PR DESCRIPTION
This change is required to make the propagation graphing actually work.
It seems this has been fixed manually on the production systems.

Signed-off-by: Adrian Reber <adrian@lisas.de>