### PR TITLE
umdl: mark paths containing /stage/ also as testing

### DIFF
--- a/mirrormanager2/lib/umdl.py
+++ b/mirrormanager2/lib/umdl.py
@@ -85,7 +85,8 @@ def create_version_from_path(session, category, path):
     ver = None
     vname = _get_version_from_path(path)
     if vname is not None and vname != '':
-        if u'/test/' in path:
+        test_paths = [ u'/test/', u'/stage/']
+        if any(x in path for x in test_paths):
             isTest = True
         else:
             isTest = False


### PR DESCRIPTION
As described in

https://fedorahosted.org/fedora-infrastructure/ticket/5185

umdl picks up repositories and versions in the alt/ tree in the staging
directory, which should not be presented on the MirrorManager main page.

umdl already has a check to see if a version is a test version and this
is now extended to also mark releases/repositories/versions in paths
containing 'stage' as 'isTest'.

Signed-off-by: Adrian Reber <adrian@lisas.de>