### PR TITLE
mirrorlist: add protocol option

### DIFF
--- a/mirrorlist/mirrorlist_client.wsgi
+++ b/mirrorlist/mirrorlist_client.wsgi
@@ -74,7 +74,7 @@ def real_client_ip(xforwardedfor):
 def request_setup(environ, request):
     fields = [
         'repo', 'arch', 'country', 'path', 'netblock', 'location',
-        'version', 'cc'
+        'version', 'cc', 'protocol'
     ]
     d = {}
     request_data = request.GET

--- a/mirrorlist/mirrorlist_client.wsgi
+++ b/mirrorlist/mirrorlist_client.wsgi
@@ -165,7 +165,7 @@ def application(environ, start_response):
         text = ""
         text += message + '\n'
         for (hostid, url) in results:
-            text += url + '\n'
+            text += url[0] + '\n'
         results = text
         response.headers['Content-Type'] = "text/plain"
     elif resulttype == 'metalink':

--- a/mirrorlist/mirrorlist_server.py
+++ b/mirrorlist/mirrorlist_server.py
@@ -409,7 +409,7 @@ def trim_to_preferred_protocols(hosts_and_urls):
 
         for p in try_protocols:
             if p in protocols:
-                url = protocols[p]
+                url = [protocols[p]]
                 break
 
         if url is not None:
@@ -682,12 +682,12 @@ def do_mirrorlist(kwargs):
         return d
 
     else:
-        host_url_list = trim_to_preferred_protocols(hosts_and_urls)
+        hosts_and_urls = trim_to_preferred_protocols(hosts_and_urls)
         d = dict(
             message=header,
             resulttype='mirrorlist',
             returncode=200,
-            results=host_url_list)
+            results=hosts_and_urls)
         return d
 
 


### PR DESCRIPTION
This adds the option specify the desired protocol of the mirrorlist/metalink as described in #100 

The code is currently running in staging and the result can be seen at:

http://mirrors.stg.fedoraproject.org/mirrorlist?repo=rawhide&arch=x86_64&country=jp&protocol=rsync
http://mirrors.stg.fedoraproject.org/mirrorlist?repo=rawhide&arch=x86_64&country=jp&protocol=ftp
http://mirrors.stg.fedoraproject.org/metalink?repo=rawhide&arch=x86_64&country=gb&protocol=https
http://mirrors.stg.fedoraproject.org/metalink?repo=rawhide&arch=x86_64&country=gb&protocol=rsync