### PR TITLE
Allow submission of checkin information via json

### DIFF
--- a/client/report_mirror
+++ b/client/report_mirror
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 
 import os, sys
-import pickle
+import json
 import ConfigParser
 import pprint
 import xmlrpclib
@@ -186,7 +186,7 @@ def get_stats(conf, section):
             try:
                 f = open(fn, 'r')
                 contents = contents + f.readlines()
-                statsdata[name] = pickle.dumps(contents, -1)
+                statsdata[name] = json.dumps(contents, -1)
                 f.close()
             except:
                 pass
@@ -284,7 +284,7 @@ def main():
     get_exclude_dir_patterns_from_file(options)
     if options.input:
         infile = open(options.input, 'rb')
-        item.config = pickle.load(infile)
+        item.config = json.load(infile)
         infile.close()
         if not config(options.config, item, crawl=False):
             sys.exit(1)
@@ -292,7 +292,7 @@ def main():
         if not config(options.config, item, crawl=True):
             sys.exit(1)
 
-    p = pickle.dumps(item.config, -1)
+    p = json.dumps(item.config, -1)
 
     if options.debug:
         pp = pprint.PrettyPrinter(indent=4)

--- a/mirrormanager2/xmlrpc.py
+++ b/mirrormanager2/xmlrpc.py
@@ -25,6 +25,7 @@ MirrorManager2 xmlrpc controller.
 
 import base64
 import pickle
+import json
 import bz2
 
 import flask
@@ -41,7 +42,11 @@ XMLRPC.connect(APP, '/xmlrpc')
 
 @XMLRPC.register
 def checkin(pickledata):
-    config = pickle.loads(bz2.decompress(base64.urlsafe_b64decode(pickledata)))
+    uncompressed = bz2.decompress(base64.urlsafe_b64decode(pickledata))
+    try:
+        config = json.loads(uncompressed)
+    except ValueError:
+        config = pickle.loads(uncompressed)
     r, message = read_host_config(SESSION, config)
     if r is not None:
         return message + 'checked in successful'


### PR DESCRIPTION
This means we still allow pickle submissions as a stopgap until we
manage to convince admins to move to json submissions.

Related: CVE-2016-1000003
Signed-off-by: Patrick Uiterwijk <puiterwijk@redhat.com>