### PR TITLE
mm2_crawler: Add missing field to stats dict

### DIFF
--- a/utility/mm2_crawler
+++ b/utility/mm2_crawler
@@ -678,8 +678,8 @@ def report_stats(stats):
 
 
 def sync_hcds(session, host, host_category_dirs, repodata):
-    stats = dict(up2date = 0, not_up2date = 0, unchanged = 0,
-                 unknown = 0, newdir = 0, deleted_on_master = 0, duration = 0)
+    stats = dict(up2date=0, not_up2date=0, unchanged=0,
+                 unknown=0, newdir=0, deleted_on_master=0, duration=0)
     current_hcds = {}
     stats['duration'] = time.time() -  threadlocal.starttime
     keys = host_category_dirs.keys()

--- a/utility/mm2_crawler
+++ b/utility/mm2_crawler
@@ -662,6 +662,8 @@ def report_stats(stats):
     logger.info(msg)
     msg = "Total directories: %d" % stats['numkeys']
     logger.info(msg)
+    msg = "Unreadable directories: %d" % stats['unreadable']
+    logger.info(msg)
     msg = "Changed to up2date: %d" % stats['up2date']
     logger.info(msg)
     msg = "Changed to not up2date: %d" % stats['not_up2date']
@@ -678,7 +680,7 @@ def report_stats(stats):
 
 
 def sync_hcds(session, host, host_category_dirs, repodata):
-    stats = dict(up2date=0, not_up2date=0, unchanged=0,
+    stats = dict(up2date=0, not_up2date=0, unchanged=0, unreadable=0,
                  unknown=0, newdir=0, deleted_on_master=0, duration=0)
     current_hcds = {}
     stats['duration'] = time.time() -  threadlocal.starttime


### PR DESCRIPTION
During the crawl of unreadable directories, which can exists in the days
before a release, the crawler tries to count the number of unreadable
directories in the stats dict. The key 'unreadable' does not exist which
means that the crawlers just stops crawling a host once the first
unreadable directory has been found. This means that the crawler will
error out on most hosts just before a release.