### PR TITLE
Add json checkin endpoint

### DIFF
--- a/mirrormanager2/app.py
+++ b/mirrormanager2/app.py
@@ -1351,7 +1351,7 @@ def auth_logout():
 
 import admin
 import api
-import xmlrpc
+import checkin
 
 # Only import the login controller if the app is set up for local login
 if APP.config.get('MM_AUTHENTICATION', None) == 'local':


### PR DESCRIPTION
This is a simple json-only endpoint that does not require xmlrpc.
It accepts both plain json and gzip compress json as input.

Signed-off-by: Patrick Uiterwijk puiterwijk@redhat.com
