### PR TITLE
python3 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ build/
 _build/
 mirrormanager2_tests.cfg
 mirrormanager2_tests_mdtr.cfg
+/.pytest_cache/

--- a/client/report_mirror
+++ b/client/report_mirror
@@ -1,5 +1,6 @@
 #!/usr/bin/python2
 
+from __future__ import print_function
 import os, sys
 import json
 import ConfigParser
@@ -127,7 +128,7 @@ def parse_section(conf, section, item, required_options,
     if conf.has_option(section, 'enabled'):
         if conf.get(section, 'enabled') != '1' \
                 and section.lower() in item.config:
-            print 'removing disabled section %s' % (section)
+            print('removing disabled section %s' % (section))
             del item.config[section.lower()]
             return False
 
@@ -321,17 +322,17 @@ def main():
 
         if data is not None:
             try:
-                print server.checkin(data)
+                print(server.checkin(data))
             except socket.error, m:
-                print "Error checking in: %s.  Please try again later." % (
-                    m[1])
+                print("Error checking in: %s.  Please try again later." % (
+                    m[1]))
             except xmlrpclib.ProtocolError:
-                print "Error checking in: Service Temporarily "\
-                    "Unavailable.  Please try again later."
+                print("Error checking in: Service Temporarily "
+                      "Unavailable.  Please try again later.")
                 sys.exit(1)
             except xmlrpclib.Fault:
-                print "Error checking in.  Connection closed before "\
-                    "checkin complete.  Please try again later."
+                print("Error checking in.  Connection closed before "
+                      "checkin complete.  Please try again later.")
                 sys.exit(1)
 
 

--- a/client/report_mirror
+++ b/client/report_mirror
@@ -3,7 +3,10 @@
 from __future__ import print_function
 import os, sys
 import json
-import ConfigParser
+try:
+    import configparser
+except ImportError:
+    import ConfigParser as configparser
 import pprint
 import xmlrpclib
 import base64
@@ -208,7 +211,7 @@ def parse_category(conf, section, item, crawl):
 
 def config(cfg, item, crawl=True):
     broken = False
-    conf = ConfigParser.ConfigParser()
+    conf = configparser.ConfigParser()
     files = conf.read(cfg)
     if files == []:
         errorprint('Configuration file %s not found' % (cfg))

--- a/client/report_mirror
+++ b/client/report_mirror
@@ -307,9 +307,7 @@ def main():
 #        statdata = get_stats(conf, 'stats')
 
     # upload p and statsdata here
-    if not item.config.has_key('global') \
-            or not item.config['global'].has_key('enabled') \
-            or item.config['global']['enabled'] != '1':
+    if item.config.get('global', {}).get('enabled') != '1':
         sys.exit(1)
 
     if not options.no_send:

--- a/client/report_mirror
+++ b/client/report_mirror
@@ -323,7 +323,7 @@ def main():
         if data is not None:
             try:
                 print(server.checkin(data))
-            except socket.error, m:
+            except socket.error as m:
                 print("Error checking in: %s.  Please try again later." % (
                     m[1]))
             except xmlrpclib.ProtocolError:

--- a/mirrorlist/mirrorlist_client.wsgi
+++ b/mirrorlist/mirrorlist_client.wsgi
@@ -117,7 +117,7 @@ def request_setup(environ, request):
     if scriptname == '/metalink' or pathinfo == '/metalink':
         d['metalink'] = True
 
-    for k, v in d.iteritems():
+    for k, v in d.items():
         try:
             d[k] = unicode(v, 'utf8', 'replace')
         except:

--- a/mirrorlist/mirrorlist_client.wsgi
+++ b/mirrorlist/mirrorlist_client.wsgi
@@ -14,7 +14,10 @@
 
 import socket
 import select
-import cPickle as pickle
+try:
+    import cPickle as pickle
+except ImportError:
+    import pickle
 from string import zfill, atoi, strip, replace
 from webob import Request, Response
 

--- a/mirrorlist/mirrorlist_client.wsgi
+++ b/mirrorlist/mirrorlist_client.wsgi
@@ -18,7 +18,6 @@ try:
     import cPickle as pickle
 except ImportError:
     import pickle
-from string import zfill, atoi, strip, replace
 from webob import Request, Response
 
 socketfile = '/var/run/mirrormanager/mirrorlist_server.sock'
@@ -35,7 +34,7 @@ def get_mirrorlist(d):
     p = pickle.dumps(d)
     del d
     size = len(p)
-    s.sendall(zfill('%s' % size, 10))
+    s.sendall(str(size).zfill(10))
 
     # write the pickle
     s.sendall(p)
@@ -53,7 +52,7 @@ def get_mirrorlist(d):
     while readlen < 10:
         resultsize += s.recv(10 - readlen)
         readlen = len(resultsize)
-    resultsize = atoi(resultsize)
+    resultsize = int(resultsize)
 
     readlen = 0
     p = ''
@@ -83,17 +82,17 @@ def request_setup(environ, request):
     request_data = request.GET
     for f in fields:
         if f in request_data:
-            d[f] = strip(request_data[f])
+            d[f] = request_data[f].strip()
             # add back '+' that were converted to ' ' by util.FieldStorage
             if f == 'path':
-                d[f] = replace(d[f], ' ', '+')
+                d[f] = d[f].replace(' ', '+')
 
     if 'ip' in request_data:
-        client_ip = strip(request_data['ip'])
+        client_ip = request_data['ip'].strip()
     elif 'X-Forwarded-For' in request.headers \
             and 'mirrorlist_client.noreverseproxy' not in environ:
         client_ip = real_client_ip(
-            strip(request.headers['X-Forwarded-For']))
+            request.headers['X-Forwarded-For'].strip())
     else:
         client_ip = request.environ['REMOTE_ADDR']
     d['client_ip'] = client_ip

--- a/mirrorlist/mirrorlist_server.py
+++ b/mirrorlist/mirrorlist_server.py
@@ -26,7 +26,6 @@ except ImportError:
     from SocketServer import (StreamRequestHandler, ThreadingMixIn,
                               UnixStreamServer, BaseServer)
 import sys
-from string import zfill, atoi
 import time
 import traceback
 
@@ -831,7 +830,7 @@ class MirrorlistHandler(StreamRequestHandler):
             while readlen < 10:
                 size += self.rfile.read(10 - readlen)
                 readlen = len(size)
-            size = atoi(size)
+            size = int(size)
 
             # read the pickle
             readlen = 0
@@ -872,7 +871,7 @@ class MirrorlistHandler(StreamRequestHandler):
                 'resulttype':resulttype,
                 'results':results,
                 'returncode':returncode})
-            self.connection.sendall(zfill('%s' % len(p), 10))
+            self.connection.sendall(str(len(p)).zfill(10))
 
             self.connection.sendall(p)
             self.connection.shutdown(socket.SHUT_WR)

--- a/mirrorlist/mirrorlist_server.py
+++ b/mirrorlist/mirrorlist_server.py
@@ -19,8 +19,12 @@ except ImportError:
 import select
 import signal
 import socket
-from SocketServer import (StreamRequestHandler, ThreadingMixIn,
-                          UnixStreamServer, BaseServer)
+try:
+    from socketserver import (StreamRequestHandler, ThreadingMixIn,
+                              UnixStreamServer, BaseServer)
+except ImportError:
+    from SocketServer import (StreamRequestHandler, ThreadingMixIn,
+                              UnixStreamServer, BaseServer)
 import sys
 from string import zfill, atoi
 import time

--- a/mirrorlist/mirrorlist_server.py
+++ b/mirrorlist/mirrorlist_server.py
@@ -315,7 +315,7 @@ def do_country(kwargs, cache, clientCountry, requested_countries, header):
 
 def do_netblocks(kwargs, cache, header):
     hostresults = set()
-    if not kwargs.has_key('netblock') or kwargs['netblock'] == "1":
+    if 'netblock' not in kwargs or kwargs['netblock'] == "1":
         tree_results = tree_lookup(database['host_netblocks_tree'], kwargs['IP'], 'hosts')
         for (prefix, hostids) in tree_results:
             for hostid in hostids:
@@ -469,9 +469,8 @@ def do_mirrorlist(kwargs):
             d['results'] = metalink_failuredoc(message)
         return d
 
-    if not (kwargs.has_key('repo') \
-            and kwargs.has_key('arch')) \
-            and not kwargs.has_key('path'):
+    if not ('repo' in kwargs and 'arch' in kwargs
+            or 'path' in kwargs):
         return return_error(
             kwargs,
             message='# either path=, or repo= and arch= must be specified')
@@ -479,7 +478,7 @@ def do_mirrorlist(kwargs):
     file = None
     cache = None
     pathIsDirectory = False
-    if kwargs.has_key('path'):
+    if 'path' in kwargs:
         path = kwargs['path'].strip('/')
 
     # Strip duplicate "//" from the path
@@ -550,7 +549,7 @@ def do_mirrorlist(kwargs):
     header, location_results = do_location(kwargs, header)
 
     requested_countries = []
-    if kwargs.has_key('country'):
+    if 'country' in kwargs:
         requested_countries = uniqueify(
             [c.upper() for c in kwargs['country'].split(',') ])
 
@@ -574,7 +573,7 @@ def do_mirrorlist(kwargs):
     else:
         print_client_country = clientCountry
 
-    if logfile and kwargs.has_key('repo') and kwargs.has_key('arch'):
+    if logfile and 'repo' in kwargs and 'arch' in kwargs:
         msg = "IP: %s; DATE: %s; COUNTRY: %s; REPO: %s; ARCH: %s\n"  % (
             (kwargs['IP'] or 'None'), time.strftime("%Y-%m-%d"),
             print_client_country, kwargs['repo'], kwargs['arch'])

--- a/mirrorlist/mirrorlist_server.py
+++ b/mirrorlist/mirrorlist_server.py
@@ -248,7 +248,7 @@ continents = {}
 
 def handle_country_continent_redirect(new_db):
     new_country_continents = GeoIP.country_continents
-    for country, continent in new_db['country_continent_redirect_cache'].iteritems():
+    for country, continent in new_db['country_continent_redirect_cache'].items():
         new_country_continents[country] = continent
     global country_continents
     country_continents = new_country_continents
@@ -257,7 +257,7 @@ def handle_country_continent_redirect(new_db):
 def setup_continents(new_db):
     new_continents = defaultdict(list)
     handle_country_continent_redirect(new_db)
-    for c, continent in country_continents.iteritems():
+    for c, continent in country_continents.items():
         new_continents[continent].append(c)
     global continents
     continents = new_continents
@@ -274,7 +274,7 @@ def do_countrylist(kwargs, cache, clientCountry, requested_countries, header):
     def collapse(d):
         """ collapses a dict {key:set(hostids)} into a set of hostids """
         s = set()
-        for country, hostids in d.iteritems():
+        for country, hostids in d.items():
             for hostid in hostids:
                 s.add(hostid)
         return s
@@ -725,7 +725,7 @@ def do_mirrorlist(kwargs):
 
 def setup_cache_tree(cache, field):
     tree = radix.Radix()
-    for k, v in cache.iteritems():
+    for k, v in cache.items():
         node = tree.add(k.strNormal())
         node.data[field] = v
     return tree

--- a/mirrorlist/mirrorlist_server.py
+++ b/mirrorlist/mirrorlist_server.py
@@ -87,10 +87,8 @@ def uniqueify(seq, idfun=None):
     result = []
     for item in seq:
         marker = idfun(item)
-        # in old Python versions:
-        # if seen.has_key(marker)
-        # but in new ones:
-        if marker in seen: continue
+        if marker in seen:
+            continue
         seen[marker] = 1
         result.append(item)
     return result

--- a/mirrorlist/mirrorlist_server.py
+++ b/mirrorlist/mirrorlist_server.py
@@ -846,7 +846,7 @@ class MirrorlistHandler(StreamRequestHandler):
             results = r['results']
             resulttype = r['resulttype']
             returncode = r['returncode']
-        except Exception, e:
+        except Exception as e:
             message=u'# Bad Request %s\n# %s' % (e, d)
             exception_msg = traceback.format_exc(e)
             sys.stderr.write(message+'\n')
@@ -1045,7 +1045,7 @@ def create_pidfile_dir(pidfile):
         return
     try:
         os.makedirs(piddir, mode=0755)
-    except OSError, err:
+    except OSError as err:
         if err.errno == 17: # File exists
             pass
         else:
@@ -1068,7 +1068,7 @@ def manage_pidfile(pidfile):
     pid = os.getpid()
     try:
         f = open(pidfile, 'r')
-    except IOError, err:
+    except IOError as err:
         if err.errno == 2: # No such file or directory
             return write_pidfile(pidfile, pid)
         return 1
@@ -1081,7 +1081,7 @@ def manage_pidfile(pidfile):
         os.kill(int(oldpid), 0)
     except ValueError: # malformed oldpid
         return write_pidfile(pidfile, pid)
-    except OSError, err:
+    except OSError as err:
         if err.errno == 3: # No such process
             return write_pidfile(pidfile, pid)
     return 1

--- a/mirrorlist/mirrorlist_server.py
+++ b/mirrorlist/mirrorlist_server.py
@@ -1044,7 +1044,7 @@ def create_pidfile_dir(pidfile):
     if not piddir:
         return
     try:
-        os.makedirs(piddir, mode=0755)
+        os.makedirs(piddir, mode=0o755)
     except OSError as err:
         if err.errno == 17: # File exists
             pass

--- a/mirrorlist/mirrorlist_server.py
+++ b/mirrorlist/mirrorlist_server.py
@@ -12,7 +12,10 @@ import logging
 import logging.handlers
 import os
 import random
-import cPickle as pickle
+try:
+    import cPickle as pickle
+except ImportError:
+    import pickle
 import select
 import signal
 import socket

--- a/mirrorlist/mirrorlist_statistics
+++ b/mirrorlist/mirrorlist_statistics
@@ -22,6 +22,7 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import sys
 import matplotlib
 matplotlib.use('Agg')
@@ -41,21 +42,21 @@ embargoed_countries = []
 
 
 def usage():
-    print "mirrorlist_statistics.py analyzes mirrorlist_server.py logfiles"
-    print "and draws piecharts"
-    print
-    print "Usage:"
-    print "  mirrorlist_statistics.py [OPTION]..."
-    print
-    print "Options:"
-    print "  -c, --config=CONFIG   Configuration file to use"
-    print "                        (default=/etc/mirrormanager/mirrormanager2.cfg)"
-    print "  -l, --log=LOGFILE     gzipped logfile which should be used as input"
-    print "  -d, --dest=DIRECTORY  output directory"
-    print "  -o, --offset=DAYS     number of days which should be subtracted"
-    print "                        from today's date and be used as basis for log analysis"
-    print "  -h, --help            show this help; then exit"
-    print
+    print("mirrorlist_statistics.py analyzes mirrorlist_server.py logfiles")
+    print("and draws piecharts")
+    print()
+    print("Usage:")
+    print("  mirrorlist_statistics.py [OPTION]...")
+    print()
+    print("Options:")
+    print("  -c, --config=CONFIG   Configuration file to use")
+    print("                        (default=/etc/mirrormanager/mirrormanager2.cfg)")
+    print("  -l, --log=LOGFILE     gzipped logfile which should be used as input")
+    print("  -d, --dest=DIRECTORY  output directory")
+    print("  -o, --offset=DAYS     number of days which should be subtracted")
+    print("                        from today's date and be used as basis for log analysis")
+    print("  -h, --help            show this help; then exit")
+    print()
 
 
 def parse_args():
@@ -80,8 +81,8 @@ def parse_args():
             sys.exit(0)
 
     if not os.access(configuration, os.R_OK):
-        print "Cannot access configuration file: " + configuration
-        print "Exiting"
+        print("Cannot access configuration file: " + configuration)
+        print("Exiting")
         sys.exit(-1)
 
     d = dict()

--- a/mirrorlist/test/server_tester.py
+++ b/mirrorlist/test/server_tester.py
@@ -4,6 +4,7 @@
 #  by Matt Domsch <Matt_Domsch@dell.com>
 # Licensed under the MIT/X11 license
 
+from __future__ import print_function
 import socket, os
 import cPickle as pickle
 from string import zfill, atoi
@@ -81,4 +82,4 @@ while True:
     start = datetime.datetime.utcnow()
     result = do_mirrorlist(d)
     end = datetime.datetime.utcnow()
-    print "[%s]   connect: %s  total: %s" % (pid, connectTime, (end-start))
+    print("[%s]   connect: %s  total: %s" % (pid, connectTime, (end-start)))

--- a/mirrorlist/test/server_tester.py
+++ b/mirrorlist/test/server_tester.py
@@ -10,7 +10,6 @@ try:
     import cPickle as pickle
 except ImportError:
     import pickle
-from string import zfill, atoi
 import datetime
 
 socketfile = '/var/run/mirrormanager/mirrorlist_server.sock'
@@ -33,7 +32,7 @@ def do_mirrorlist(d):
     p = pickle.dumps(d)
     size = len(p)
     #print "writing size %s to server" % size
-    s.sendall(zfill('%s' % size, 10))
+    s.sendall(str(size).zfill(10))
 
     # write the pickle
     #print "writing the pickle"
@@ -47,7 +46,7 @@ def do_mirrorlist(d):
     while readlen < 10:
         resultsize += s.recv(10 - readlen)
         readlen = len(resultsize)
-    resultsize = atoi(resultsize)
+    resultsize = int(resultsize)
 
     #print "reading %s bytes of the results list" % resultsize
     readlen = 0

--- a/mirrorlist/test/server_tester.py
+++ b/mirrorlist/test/server_tester.py
@@ -6,7 +6,10 @@
 
 from __future__ import print_function
 import socket, os
-import cPickle as pickle
+try:
+    import cPickle as pickle
+except ImportError:
+    import pickle
 from string import zfill, atoi
 import datetime
 

--- a/mirrorlist/test/server_tester.py
+++ b/mirrorlist/test/server_tester.py
@@ -72,7 +72,7 @@ while True:
          'arch':'i386',
          'metalink':False}
 
-    for k, v in d.iteritems():
+    for k, v in d.items():
         try:
             d[k] = unicode(v, 'utf8', 'replace')
         except:

--- a/mirrorlist/weighted_shuffle.py
+++ b/mirrorlist/weighted_shuffle.py
@@ -2,6 +2,8 @@
 #  by Matt Domsch <Matt_Domsch@dell.com>
 # Licensed under the MIT/X11 license
 
+from __future__ import print_function
+
 import random
 import bisect
 
@@ -86,4 +88,4 @@ def unit_test():
     while 1:
         l = [(1000, 1), (1000, 2), (100, 3), (100, 4), (10, 5), (10, 6), (10, 7), (10, 8)]
         newlist = weighted_shuffle(l)
-        print newlist
+        print(newlist)

--- a/mirrormanager2/app.py
+++ b/mirrormanager2/app.py
@@ -118,7 +118,7 @@ def is_mirrormanager_admin(user):
 
     if auth_method in ('fas', 'local'):
         admins = APP.config['ADMIN_GROUP']
-        if isinstance(admins, basestring):
+        if isinstance(admins, str):
             admins = [admins]
         admins = set(admins)
 

--- a/mirrormanager2/app.py
+++ b/mirrormanager2/app.py
@@ -23,7 +23,6 @@
 MirrorManager2 main flask controller.
 '''
 
-
 import logging
 import logging.handlers
 import glob
@@ -1257,7 +1256,7 @@ def rsyncFilter():
     def parents(folder):
         path = []
         splitpath = folder.split('/')
-        for i in xrange(1, len(splitpath)):
+        for i in range(1, len(splitpath)):
             path.append('/'.join(splitpath[:i]))
         return path
 
@@ -1298,7 +1297,7 @@ def rsyncFilter():
     newer_dirs = mirrormanager2.lib.get_rsync_filter_directories(
         SESSION, categories_requested, since)
 
-    for i in xrange(len(newer_dirs)):
+    for i in range(len(newer_dirs)):
         newer_dirs[i] = strip_prefix(num_prefix, newer_dirs[i])
 
     includes.update(newer_dirs)
@@ -1307,7 +1306,7 @@ def rsyncFilter():
 
     includes = sorted(includes)
     # add trailing slash as rsync wants it
-    for i in xrange(len(includes)):
+    for i in range(len(includes)):
         includes[i] += u'/'
 
     return flask.render_template(

--- a/mirrormanager2/app.py
+++ b/mirrormanager2/app.py
@@ -23,6 +23,7 @@
 MirrorManager2 main flask controller.
 '''
 
+from __future__ import absolute_import
 import logging
 import logging.handlers
 import glob
@@ -371,7 +372,7 @@ def site_view(site_id):
     )
 
 
-from lib.notifications import fedmsg_publish
+from .lib.notifications import fedmsg_publish
 
 
 @APP.route('/site/<int:site_id>/drop', methods=['POST'])
@@ -1356,9 +1357,9 @@ def auth_logout():
         login.logout()
     return flask.redirect(next_url)
 
-import admin
-import api
-import xmlrpc
+from . import admin
+from . import api
+from . import xmlrpc
 
 # Only import the login controller if the app is set up for local login
 if APP.config.get('MM_AUTHENTICATION', None) == 'local':

--- a/mirrormanager2/forms.py
+++ b/mirrormanager2/forms.py
@@ -34,8 +34,12 @@ MirrorManager2 forms.
 
 
 import re
-import flask_wtf as wtf
 import wtforms
+try:
+    from flask_wtf import FlaskForm
+except ImportError:
+    from flask_wtf import Form as FlaskForm
+
 from flask import g
 
 import IPy
@@ -55,12 +59,12 @@ def is_number(form, field):
         raise wtforms.ValidationError('Field must contain a number')
 
 
-class ConfirmationForm(wtf.Form):
+class ConfirmationForm(FlaskForm):
     """ Simple form, just used for CSRF protection. """
     pass
 
 
-class AddSiteForm(wtf.Form):
+class AddSiteForm(FlaskForm):
     """ Form to add or edit a site. """
     name = wtforms.TextField(
         'Site name',
@@ -95,7 +99,7 @@ class AddSiteForm(wtf.Form):
     )
 
 
-class AddHostForm(wtf.Form):
+class AddHostForm(FlaskForm):
     """ Form to add or edit a host. """
     name = wtforms.TextField(
         'Host name  <span class="error">*</span>',
@@ -160,7 +164,7 @@ class AddHostForm(wtf.Form):
     )
 
 
-class AddHostAclIpForm(wtf.Form):
+class AddHostAclIpForm(FlaskForm):
     """ Form to add or edit a host_acl_ip. """
     ip = wtforms.TextField(
         'IP  <span class="error">*</span>',
@@ -190,7 +194,7 @@ def validate_netblocks(form, field):
         raise wtforms.validators.ValidationError(emsg)
 
 
-class AddHostNetblockForm(wtf.Form):
+class AddHostNetblockForm(FlaskForm):
     """ Form to add or edit a host_netblock. """
     name = wtforms.TextField(
         'Name  <span class="error">*</span>',
@@ -202,7 +206,7 @@ class AddHostNetblockForm(wtf.Form):
     )
 
 
-class AddHostAsnForm(wtf.Form):
+class AddHostAsnForm(FlaskForm):
     """ Form to add or edit a host_peer_asn. """
     name = wtforms.TextField(
         'Name  <span class="error">*</span>',
@@ -214,7 +218,7 @@ class AddHostAsnForm(wtf.Form):
     )
 
 
-class AddHostCountryForm(wtf.Form):
+class AddHostCountryForm(FlaskForm):
     """ Form to add or edit a host_country. """
     country = wtforms.TextField(
         'Country  <span class="error">*</span>',
@@ -225,7 +229,7 @@ class AddHostCountryForm(wtf.Form):
     )
 
 
-class AddHostCategoryForm(wtf.Form):
+class AddHostCategoryForm(FlaskForm):
     """ Form to add a host_category. """
     category_id = wtforms.SelectField(
         'Category',
@@ -250,7 +254,7 @@ class AddHostCategoryForm(wtf.Form):
             ]
 
 
-class EditHostCategoryForm(wtf.Form):
+class EditHostCategoryForm(FlaskForm):
     """ Form to edit a host_category. """
     always_up2date = wtforms.BooleanField(
         'Always up to date',
@@ -258,7 +262,7 @@ class EditHostCategoryForm(wtf.Form):
     )
 
 
-class AddHostCategoryUrlForm(wtf.Form):
+class AddHostCategoryUrlForm(FlaskForm):
     """ Form to add a host_category_url. """
     p = APP.config.get('MM_PROTOCOL_REGEX', '')
     url = wtforms.TextField(

--- a/mirrormanager2/lib/__init__.py
+++ b/mirrormanager2/lib/__init__.py
@@ -1023,7 +1023,7 @@ def uploaded_config(session, host, config):
         dfiles = hcdir.directory.files
         if len(dfiles) == 0 and len(files) == 0:
             return True
-        for fname, fdata in dfiles.iteritems():
+        for fname, fdata in dfiles.items():
             if fname not in files:
                 return False
             if fdata['size'] != files[fname]:
@@ -1056,7 +1056,7 @@ def uploaded_config(session, host, config):
         deleted = 0
         added = 0
         # and now one HostCategoryDir for each dir in the dirtree
-        for dirname,files in config[cat_name]['dirtree'].iteritems():
+        for dirname,files in config[cat_name]['dirtree'].items():
             d = dirname.strip('/')
             hcdir = get_hostcategorydir_by_hostcategoryid_and_path(
                 session, host_category_id=hc.id, path=d)

--- a/mirrormanager2/lib/__init__.py
+++ b/mirrormanager2/lib/__init__.py
@@ -1035,7 +1035,7 @@ def uploaded_config(session, host, config):
     # so we have to find the matching mixed-case category name.
 
     for cat_name in _config_categories(config):
-        if not config[cat_name].has_key('dirtree'):
+        if 'dirtree' not in config[cat_name]:
             # The received report_mirror data is missing
             # the actual data. Pretty unlikely, but possible.
             continue

--- a/mirrormanager2/lib/hostconfig.py
+++ b/mirrormanager2/lib/hostconfig.py
@@ -36,7 +36,7 @@ def validate_config(config):
         message += 'config file is not a dict.\n'\
         'Please update your copy of report_mirror.\n'
         return (False, message)
-    if not config.has_key('version'):
+    if 'version' not in config:
         message += 'config file has no version field.\n'
         return (False, message)
     # this field is an integer
@@ -46,26 +46,26 @@ def validate_config(config):
         return (False, message)
 
     for section in ['global', 'site', 'host']:
-        if not config.has_key(section):
+        if section not in config:
             message += 'config file missing section %s.\n' % (section)
             return (False, message)
 
     globl = config['global']
     # this field is a string as it comes from the config file
-    if not globl.has_key('enabled') or globl['enabled'] != '1':
+    if 'enabled' not in globl or globl['enabled'] != '1':
         message += 'config file section [global] not enabled.\n'
         return (False, message)
 
     site = config['site']
     for opt in ['name', 'password']:
-        if not site.has_key(opt):
+        if opt not in site:
             message += 'config file [site] missing required option %s.'\
                 '\n' % (opt)
             return (False, message)
 
     host = config['host']
     for opt in ['name']:
-        if not host.has_key(opt):
+        if opt not in host:
             message +=  'section [host] missing required option %s.\n' % (
                 opt)
             return (False, message)
@@ -75,7 +75,7 @@ def validate_config(config):
             continue
 
         for opt in ['dirtree']:
-            if not config[category].has_key(opt):
+            if opt not in config[category]:
                 message += 'section [%s] missing required option %s.\n' % (
                     category, opt)
                 return (False, message)
@@ -108,7 +108,7 @@ def read_host_config(session, config):
         return (None, 'Config file host name for site not found.\n')
 
     # handle the optional arguments
-    if config['host'].has_key('user_active'):
+    if 'user_active' in config['host']:
         if config['host']['user_active'] in ['true', '1', 't', 'y', 'yes']:
             host.user_active = True
         else:

--- a/mirrormanager2/lib/mirrorlist.py
+++ b/mirrormanager2/lib/mirrorlist.py
@@ -24,7 +24,10 @@ from __future__ import print_function
 import datetime
 import os
 import hashlib
-import cPickle as pickle
+try:
+    import cPickle as pickle
+except ImportError:
+    import pickle
 
 from operator import itemgetter
 

--- a/mirrormanager2/lib/mirrorlist.py
+++ b/mirrormanager2/lib/mirrorlist.py
@@ -19,6 +19,8 @@
 # of Red Hat, Inc.
 #
 
+from __future__ import print_function
+
 import datetime
 import os
 import hashlib
@@ -399,6 +401,6 @@ def dump_caches(session, filename):
         f.close()
         #print 'Pickle generated at %s' % filename
     except Exception as err:
-        print 'Error generating the pickle (%s): %s' % (
-            filename, err)
+        print('Error generating the pickle (%s): %s' % (
+            filename, err))
         pass

--- a/mirrormanager2/lib/model.py
+++ b/mirrormanager2/lib/model.py
@@ -329,7 +329,7 @@ class Directory(BASE):
         stale = t - (60 * 60 * 24 * max_stale)
         propogation = t - (60 * 60 * 24 * max_propogation)
 
-        for k, fds in cls.file_details_cache.iteritems():
+        for k, fds in cls.file_details_cache.items():
             (directory_id, filename) = k
             if len(fds) > 1:
                 start = 2

--- a/mirrormanager2/lib/model.py
+++ b/mirrormanager2/lib/model.py
@@ -367,14 +367,15 @@ class Product(BASE):
                 versions[version.name] = version
 
         # Try to "smartly" sort versions for display.
-        def intify(value):
+        # Return a tuple for sorting to avoid str↔int comparisons under python3
+        def intify(item):
+            k, v = item
             try:
-                return int(value)
+                return (0, int(k))
             except ValueError:
-                return value
+                return (1, k)
 
-        keys = [intify(key) for key in versions]
-        return [versions[str(key)] for key in sorted(keys, reverse=True)]
+        return [v for k,v in sorted(versions.items(), reverse=True, key=intify)]
 
 
 class Category(BASE):

--- a/mirrormanager2/lib/notifications.py
+++ b/mirrormanager2/lib/notifications.py
@@ -42,7 +42,7 @@ def fedmsg_publish(*args, **kwargs):  # pragma: no cover
     try:
         import fedmsg
         fedmsg.publish(*args, **kwargs)
-    except Exception, err:
+    except Exception as err:
         warnings.warn(str(err))
 
 

--- a/mirrormanager2/lib/pid.py
+++ b/mirrormanager2/lib/pid.py
@@ -54,7 +54,7 @@ def manage_pidfile(pidfile):
     try:
         with open(pidfile, 'r') as stream:
             oldpid = stream.read()
-    except IOError, err:
+    except IOError as err:
         return 1
 
     # is the oldpid process still running?
@@ -62,7 +62,7 @@ def manage_pidfile(pidfile):
         os.kill(int(oldpid), 0)
     except ValueError:  # malformed oldpid
         return write_pidfile(pidfile, pid)
-    except OSError, err:
+    except OSError as err:
         if err.errno == 3:  # No such process
             return write_pidfile(pidfile, pid)
     return 1

--- a/mirrormanager2/lib/pid.py
+++ b/mirrormanager2/lib/pid.py
@@ -33,7 +33,7 @@ def remove_pidfile(pidfile):
 def create_pidfile_dir(pidfile):
     piddir = os.path.dirname(pidfile)
     if piddir and not os.path.exists(piddir):
-        os.makedirs(piddir, mode=0755)
+        os.makedirs(piddir, mode=0o755)
 
 
 def write_pidfile(pidfile, pid):

--- a/mirrormanager2/lib/sync.py
+++ b/mirrormanager2/lib/sync.py
@@ -74,7 +74,7 @@ def run_rsync(rsyncpath, extra_rsync_args=None, logger=None, timeout=None):
     :returns: return code, file descriptor
     """
 
-    tmpfile = tempfile.SpooledTemporaryFile()
+    tmpfile = tempfile.SpooledTemporaryFile(mode='w+t')
     cmd = "rsync --temp-dir=/tmp -r --exclude=.snapshot --exclude='*.~tmp~'"
     if extra_rsync_args is not None:
         cmd += ' ' + extra_rsync_args

--- a/mirrormanager2/login.py
+++ b/mirrormanager2/login.py
@@ -129,7 +129,7 @@ def do_login():
                 flask.g.fas_user = user_obj
                 flask.g.fas_session_id = visit_key
                 flask.flash('Welcome %s' % user_obj.username)
-            except SQLAlchemyError, err:  # pragma: no cover
+            except SQLAlchemyError as err:  # pragma: no cover
                 flask.flash(
                     'Could not set the session in the db, '
                     'please report this error to an admin', 'error')
@@ -156,7 +156,7 @@ def confirm_user(token):
             SESSION.commit()
             flask.flash('Email confirmed, account activated')
             return flask.redirect(flask.url_for('auth_login'))
-        except SQLAlchemyError, err:  # pragma: no cover
+        except SQLAlchemyError as err:  # pragma: no cover
             flask.flash(
                 'Could not set the account as active in the db, '
                 'please report this error to an admin', 'error')
@@ -362,7 +362,7 @@ def _check_session_cookie():
                 SESSION.add(session)
                 try:
                     SESSION.commit()
-                except SQLAlchemyError, err:  # pragma: no cover
+                except SQLAlchemyError as err:  # pragma: no cover
                     flask.flash(
                         'Could not prolong the session in the db, '
                         'please report this error to an admin', 'error')

--- a/mirrormanager2/login_forms.py
+++ b/mirrormanager2/login_forms.py
@@ -35,6 +35,10 @@ MirrorManager2 login forms.
 
 import flask_wtf as wtf
 import wtforms
+try:
+    from flask_wtf import FlaskForm
+except ImportError:
+    from flask_wtf import Form as FlaskForm
 
 
 def same_password(form, field):
@@ -44,7 +48,7 @@ def same_password(form, field):
         raise wtf.ValidationError('Both password fields should be equal')
 
 
-class LostPasswordForm(wtf.Form):
+class LostPasswordForm(FlaskForm):
     """ Form to ask for a password change. """
     username = wtforms.TextField(
         'username  <span class="error">*</span>',
@@ -52,7 +56,7 @@ class LostPasswordForm(wtf.Form):
     )
 
 
-class ResetPasswordForm(wtf.Form):
+class ResetPasswordForm(FlaskForm):
     """ Form to reset one's password in the local database. """
     password = wtforms.PasswordField(
         'Password  <span class="error">*</span>',
@@ -64,7 +68,7 @@ class ResetPasswordForm(wtf.Form):
     )
 
 
-class LoginForm(wtf.Form):
+class LoginForm(FlaskForm):
     """ Form to login via the local database. """
     username = wtforms.TextField(
         'username  <span class="error">*</span>',
@@ -76,7 +80,7 @@ class LoginForm(wtf.Form):
     )
 
 
-class NewUserForm(wtf.Form):
+class NewUserForm(FlaskForm):
     """ Form to add a new user to the local database. """
     user_name = wtforms.TextField(
         'username  <span class="error">*</span>',

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -4,6 +4,8 @@
 mirrormanager2 tests.
 '''
 
+from __future__ import print_function
+
 __requires__ = ['SQLAlchemy >= 0.7']
 import pkg_resources
 
@@ -33,7 +35,7 @@ if os.environ.get('BUILD_ID'):
         req = requests.get('%s/new' % FAITOUT_URL)
         if req.status_code == 200:
             DB_PATH = req.text
-            print 'Using faitout at: %s' % DB_PATH
+            print('Using faitout at: %s' % DB_PATH)
     except:
         pass
 

--- a/tests/test_mdtr.py
+++ b/tests/test_mdtr.py
@@ -65,7 +65,8 @@ class MDTLTest(tests.Modeltests):
 
         process = subprocess.Popen(
             args=command,
-            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+            universal_newlines=True)
         stdout, stderr = process.communicate()
 
         self.assertEqual(stderr, '')
@@ -82,7 +83,8 @@ class MDTLTest(tests.Modeltests):
 
         process = subprocess.Popen(
             args=command,
-            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+            universal_newlines=True)
         stdout, stderr = process.communicate()
 
         self.assertEqual(stdout, 'Version 27 not found for product Fedora\n')
@@ -93,7 +95,8 @@ class MDTLTest(tests.Modeltests):
 
         process = subprocess.Popen(
             args=command,
-            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+            universal_newlines=True)
         stdout, stderr = process.communicate()
 
         self.assertEqual(stdout, '')
@@ -203,7 +206,8 @@ class MDTLTest(tests.Modeltests):
 
         process = subprocess.Popen(
             args=command[:],
-            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+            universal_newlines=True)
         stdout, stderr = process.communicate()
 
         self.assertEqual(
@@ -271,7 +275,8 @@ class MDTLTest(tests.Modeltests):
 
         process = subprocess.Popen(
             args=command[:],
-            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+            universal_newlines=True)
         stdout, stderr = process.communicate()
 
         self.assertEqual(

--- a/tests/test_mdtr.py
+++ b/tests/test_mdtr.py
@@ -4,6 +4,8 @@
 mirrormanager2 tests for the `Move Devel To Release` (MDTL) script.
 '''
 
+from __future__ import print_function
+
 __requires__ = ['SQLAlchemy >= 0.7']
 import pkg_resources
 

--- a/tests/test_mta.py
+++ b/tests/test_mta.py
@@ -59,7 +59,8 @@ class MTATest(tests.Modeltests):
 
         process = subprocess.Popen(
             args=command,
-            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+            universal_newlines=True)
         stdout, stderr = process.communicate()
 
         self.assertEqual(stderr, '')
@@ -77,7 +78,8 @@ class MTATest(tests.Modeltests):
 
         process = subprocess.Popen(
             args=command,
-            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+            universal_newlines=True)
         stdout, stderr = process.communicate()
 
         self.assertEqual(
@@ -156,7 +158,8 @@ class MTATest(tests.Modeltests):
 
         process = subprocess.Popen(
             args=command,
-            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+            universal_newlines=True)
         stdout, stderr = process.communicate()
 
         self.assertEqual(
@@ -178,7 +181,8 @@ class MTATest(tests.Modeltests):
 
         process = subprocess.Popen(
             args=command,
-            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+            universal_newlines=True)
         stdout, stderr = process.communicate()
 
         self.assertEqual(

--- a/tests/test_ui_admin.py
+++ b/tests/test_ui_admin.py
@@ -77,21 +77,23 @@ class FlaskUiAdminTest(tests.Modeltests):
         with tests.user_set(mirrormanager2.app.APP, user):
             output = self.app.get('/admin/')
             self.assertEqual(output.status_code, 200)
-            self.assertTrue('<title>Home - Admin</title>' in output.data)
+            data = output.get_data(as_text=True)
+            self.assertTrue('<title>Home - Admin</title>' in data)
             self.assertFalse(
-                '<a href="/admin/archview/">Arch</a>' in output.data)
+                '<a href="/admin/archview/">Arch</a>' in data)
             self.assertFalse(
-                '<a href="/admin/categoryview/">Category</a>' in output.data)
+                '<a href="/admin/categoryview/">Category</a>' in data)
 
         user = tests.FakeFasUserAdmin()
         with tests.user_set(mirrormanager2.app.APP, user):
             output = self.app.get('/admin/')
             self.assertEqual(output.status_code, 200)
-            self.assertTrue('<title>Home - Admin</title>' in output.data)
+            data = output.get_data(as_text=True)
+            self.assertTrue('<title>Home - Admin</title>' in data)
             self.assertTrue(re.search(
-                '<a href="/admin/arch(view)?/">Arch</a>', output.data))
+                '<a href="/admin/arch(view)?/">Arch</a>', data))
             self.assertTrue(re.search(
-                '<a href="/admin/category(view)?/">Category</a>', output.data))
+                '<a href="/admin/category(view)?/">Category</a>', data))
 
     @patch('mirrormanager2.app.is_mirrormanager_admin')
     def test_admin_arch(self, login_func):
@@ -102,16 +104,17 @@ class FlaskUiAdminTest(tests.Modeltests):
         with tests.user_set(mirrormanager2.app.APP, user):
             output = self.handle_flask_admin_urls('/admin/arch/')
             self.assertEqual(output.status_code, 200)
-            self.assertTrue('<title>Arch - Admin</title>' in output.data)
+            data = output.get_data(as_text=True)
+            self.assertTrue('<title>Arch - Admin</title>' in data)
             self.assertTrue(re.search(
-                '<a href="/admin/arch(view)?/">Arch</a>', output.data))
+                '<a href="/admin/arch(view)?/">Arch</a>', data))
             self.assertTrue(re.search(
-                '<a href="/admin/category(view)?/">Category</a>', output.data))
+                '<a href="/admin/category(view)?/">Category</a>', data))
             self.assertTrue(re.search(
                 '<a href="/admin/arch(view)?/\?sort=0" '
-                'title="Sort by Name">Name</a>', output.data))
+                'title="Sort by Name">Name</a>', data))
             self.assertTrue(
-                '<a href="javascript:void(0)">List (4)</a>' in output.data)
+                '<a href="javascript:void(0)">List (4)</a>' in data)
 
     @patch('mirrormanager2.app.is_mirrormanager_admin')
     def test_admin_category(self, login_func):
@@ -122,16 +125,17 @@ class FlaskUiAdminTest(tests.Modeltests):
         with tests.user_set(mirrormanager2.app.APP, user):
             output = self.handle_flask_admin_urls('/admin/category/')
             self.assertEqual(output.status_code, 200)
-            self.assertTrue('<title>Category - Admin</title>' in output.data)
+            data = output.get_data(as_text=True)
+            self.assertTrue('<title>Category - Admin</title>' in data)
             self.assertTrue(re.search(
-                '<a href="/admin/arch(view)?/">Arch</a>', output.data))
+                '<a href="/admin/arch(view)?/">Arch</a>', data))
             self.assertTrue(re.search(
-                '<a href="/admin/category(view)?/">Category</a>', output.data))
+                '<a href="/admin/category(view)?/">Category</a>', data))
             self.assertTrue(re.search(
                 '<a href="/admin/category(view)?/\?sort=[02]" '
-                'title="Sort by Name">Name</a>', output.data))
+                'title="Sort by Name">Name</a>', data))
             self.assertTrue(
-                '<a href="javascript:void(0)">List (2)</a>' in output.data)
+                '<a href="javascript:void(0)">List (2)</a>' in data)
 
     @patch('mirrormanager2.app.is_mirrormanager_admin')
     def test_admin_country(self, login_func):
@@ -142,17 +146,18 @@ class FlaskUiAdminTest(tests.Modeltests):
         with tests.user_set(mirrormanager2.app.APP, user):
             output = self.handle_flask_admin_urls('/admin/country/')
             self.assertEqual(output.status_code, 200)
+            data = output.get_data(as_text=True)
             self.assertTrue(
-                '<title>Country - Country - Admin</title>' in output.data)
+                '<title>Country - Country - Admin</title>' in data)
             self.assertTrue(re.search(
-                '<a href="/admin/arch(view)?/">Arch</a>', output.data))
+                '<a href="/admin/arch(view)?/">Arch</a>', data))
             self.assertTrue(re.search(
-                '<a href="/admin/category(view)?/">Category</a>', output.data))
+                '<a href="/admin/category(view)?/">Category</a>', data))
             self.assertTrue(re.search(
                 '<a href="/admin/country(view)?/\?sort=0" '
-                'title="Sort by Code">Code</a>', output.data))
+                'title="Sort by Code">Code</a>', data))
             self.assertTrue(
-                '<a href="javascript:void(0)">List (2)</a>' in output.data)
+                '<a href="javascript:void(0)">List (2)</a>' in data)
 
     @patch('mirrormanager2.app.is_mirrormanager_admin')
     def test_admin_countrycontinentredirectview(self, login_func):
@@ -164,18 +169,19 @@ class FlaskUiAdminTest(tests.Modeltests):
             output = self.handle_flask_admin_urls(
                 '/admin/countrycontinentredirect/')
             self.assertEqual(output.status_code, 200)
+            data = output.get_data(as_text=True)
             self.assertTrue(
                 '<title>Country - Country Continent Redirect - Admin'
-                '</title>' in output.data)
+                '</title>' in data)
             self.assertTrue(re.search(
-                '<a href="/admin/arch(view)?/">Arch</a>', output.data))
+                '<a href="/admin/arch(view)?/">Arch</a>', data))
             self.assertTrue(re.search(
-                '<a href="/admin/category(view)?/">Category</a>', output.data))
+                '<a href="/admin/category(view)?/">Category</a>', data))
             self.assertTrue(re.search(
                 '<a href="/admin/countrycontinentredirect(view)?/\?sort=0" '
-                'title="Sort by Country">Country</a>', output.data))
+                'title="Sort by Country">Country</a>', data))
             self.assertTrue(
-                '<a href="javascript:void(0)">List (3)</a>' in output.data)
+                '<a href="javascript:void(0)">List (3)</a>' in data)
 
     @patch('mirrormanager2.app.is_mirrormanager_admin')
     def test_admin_embargoedcountryview(self, login_func):
@@ -186,18 +192,19 @@ class FlaskUiAdminTest(tests.Modeltests):
         with tests.user_set(mirrormanager2.app.APP, user):
             output = self.handle_flask_admin_urls('/admin/embargoedcountry/')
             self.assertEqual(output.status_code, 200)
+            data = output.get_data(as_text=True)
             self.assertTrue(
                 '<title>Country - Embargoed Country - Admin'
-                '</title>' in output.data)
+                '</title>' in data)
             self.assertTrue(re.search(
-                '<a href="/admin/arch(view)?/">Arch</a>', output.data))
+                '<a href="/admin/arch(view)?/">Arch</a>', data))
             self.assertTrue(re.search(
-                '<a href="/admin/category(view)?/">Category</a>', output.data))
+                '<a href="/admin/category(view)?/">Category</a>', data))
             self.assertTrue(re.search(
                 '<a href="/admin/embargoedcountry(view)?/\?sort=0" '
-                'title="Sort by Country Code">Country Code</a>', output.data))
+                'title="Sort by Country Code">Country Code</a>', data))
             self.assertTrue(
-                '<a href="javascript:void(0)">List (0)</a>' in output.data)
+                '<a href="javascript:void(0)">List (0)</a>' in data)
 
     @patch('mirrormanager2.app.is_mirrormanager_admin')
     def test_admin_directoryview(self, login_func):
@@ -208,18 +215,19 @@ class FlaskUiAdminTest(tests.Modeltests):
         with tests.user_set(mirrormanager2.app.APP, user):
             output = self.handle_flask_admin_urls('/admin/directory/')
             self.assertEqual(output.status_code, 200)
+            data = output.get_data(as_text=True)
             self.assertTrue(
                 '<title>Directory - Directory - Admin'
-                '</title>' in output.data)
+                '</title>' in data)
             self.assertTrue(re.search(
-                '<a href="/admin/arch(view)?/">Arch</a>', output.data))
+                '<a href="/admin/arch(view)?/">Arch</a>', data))
             self.assertTrue(re.search(
-                '<a href="/admin/category(view)?/">Category</a>', output.data))
+                '<a href="/admin/category(view)?/">Category</a>', data))
             self.assertTrue(re.search(
                 '<a href="/admin/directory(view)?/\?sort=0" '
-                'title="Sort by Name">Name</a>', output.data))
+                'title="Sort by Name">Name</a>', data))
             self.assertTrue(
-                '<a href="javascript:void(0)">List (9)</a>' in output.data)
+                '<a href="javascript:void(0)">List (9)</a>' in data)
 
     @patch('mirrormanager2.app.is_mirrormanager_admin')
     def test_admin_directoryexclusivehostview(self, login_func):
@@ -231,17 +239,18 @@ class FlaskUiAdminTest(tests.Modeltests):
             output = self.handle_flask_admin_urls(
                 '/admin/directoryexclusivehost/')
             self.assertEqual(output.status_code, 200)
+            data = output.get_data(as_text=True)
             self.assertTrue(
                 '<title>Directory - Directory Exclusive Host - Admin'
-                '</title>' in output.data)
+                '</title>' in data)
             self.assertTrue(re.search(
-                '<a href="/admin/arch(view)?/">Arch</a>', output.data))
+                '<a href="/admin/arch(view)?/">Arch</a>', data))
             self.assertTrue(re.search(
-                '<a href="/admin/category(view)?/">Category</a>', output.data))
+                '<a href="/admin/category(view)?/">Category</a>', data))
             self.assertEqual(
-                output.data.count('<th class="column-header">'), 3)
+                data.count('<th class="column-header">'), 3)
             self.assertTrue(
-                '<a href="javascript:void(0)">List (0)</a>' in output.data)
+                '<a href="javascript:void(0)">List (0)</a>' in data)
 
     @patch('mirrormanager2.app.is_mirrormanager_admin')
     def test_admin_filedetailview(self, login_func):
@@ -252,18 +261,19 @@ class FlaskUiAdminTest(tests.Modeltests):
         with tests.user_set(mirrormanager2.app.APP, user):
             output = self.handle_flask_admin_urls('/admin/filedetail/')
             self.assertEqual(output.status_code, 200)
+            data = output.get_data(as_text=True)
             self.assertTrue(
                 '<title>File - File Detail - Admin'
-                '</title>' in output.data)
+                '</title>' in data)
             self.assertTrue(re.search(
-                '<a href="/admin/arch(view)?/">Arch</a>', output.data))
+                '<a href="/admin/arch(view)?/">Arch</a>', data))
             self.assertTrue(re.search(
-                '<a href="/admin/category(view)?/">Category</a>', output.data))
+                '<a href="/admin/category(view)?/">Category</a>', data))
             self.assertTrue(re.search(
                 '<a href="/admin/filedetail(view)?/\?sort=[01]" '
-                'title="Sort by Filename">Filename</a>', output.data))
+                'title="Sort by Filename">Filename</a>', data))
             self.assertTrue(
-                '<a href="javascript:void(0)">List (0)</a>' in output.data)
+                '<a href="javascript:void(0)">List (0)</a>' in data)
 
     @patch('mirrormanager2.app.is_mirrormanager_admin')
     def test_admin_filedetailfilegroupview(self, login_func):
@@ -275,17 +285,18 @@ class FlaskUiAdminTest(tests.Modeltests):
             output = self.handle_flask_admin_urls(
                 '/admin/filedetailfilegroup/')
             self.assertEqual(output.status_code, 200)
+            data = output.get_data(as_text=True)
             self.assertTrue(
                 '<title>File - File Detail File Group - Admin'
-                '</title>' in output.data)
+                '</title>' in data)
             self.assertTrue(re.search(
-                '<a href="/admin/arch(view)?/">Arch</a>', output.data))
+                '<a href="/admin/arch(view)?/">Arch</a>', data))
             self.assertTrue(re.search(
-                '<a href="/admin/category(view)?/">Category</a>', output.data))
+                '<a href="/admin/category(view)?/">Category</a>', data))
             self.assertEqual(
-                output.data.count('<th class="column-header">'), 0)
+                data.count('<th class="column-header">'), 0)
             self.assertTrue(
-                '<a href="javascript:void(0)">List (0)</a>' in output.data)
+                '<a href="javascript:void(0)">List (0)</a>' in data)
 
     @patch('mirrormanager2.app.is_mirrormanager_admin')
     def test_admin_filegroupview(self, login_func):
@@ -296,18 +307,19 @@ class FlaskUiAdminTest(tests.Modeltests):
         with tests.user_set(mirrormanager2.app.APP, user):
             output = self.handle_flask_admin_urls('/admin/filegroup/')
             self.assertEqual(output.status_code, 200)
+            data = output.get_data(as_text=True)
             self.assertTrue(
                 '<title>File - File Group - Admin'
-                '</title>' in output.data)
+                '</title>' in data)
             self.assertTrue(re.search(
-                '<a href="/admin/arch(view)?/">Arch</a>', output.data))
+                '<a href="/admin/arch(view)?/">Arch</a>', data))
             self.assertTrue(re.search(
-                '<a href="/admin/category(view)?/">Category</a>', output.data))
+                '<a href="/admin/category(view)?/">Category</a>', data))
             self.assertTrue(re.search(
                 '<a href="/admin/filegroup(view)?/\?sort=0" '
-                'title="Sort by Name">Name</a>', output.data))
+                'title="Sort by Name">Name</a>', data))
             self.assertTrue(
-                '<a href="javascript:void(0)">List (0)</a>' in output.data)
+                '<a href="javascript:void(0)">List (0)</a>' in data)
 
     @patch('mirrormanager2.app.is_mirrormanager_admin')
     def test_admin_hostview(self, login_func):
@@ -318,18 +330,19 @@ class FlaskUiAdminTest(tests.Modeltests):
         with tests.user_set(mirrormanager2.app.APP, user):
             output = self.handle_flask_admin_urls('/admin/host/')
             self.assertEqual(output.status_code, 200)
+            data = output.get_data(as_text=True)
             self.assertTrue(
                 '<title>Host - Host - Admin'
-                '</title>' in output.data)
+                '</title>' in data)
             self.assertTrue(re.search(
-                '<a href="/admin/arch(view)?/">Arch</a>', output.data))
+                '<a href="/admin/arch(view)?/">Arch</a>', data))
             self.assertTrue(re.search(
-                '<a href="/admin/category(view)?/">Category</a>', output.data))
+                '<a href="/admin/category(view)?/">Category</a>', data))
             self.assertTrue(re.search(
                 '<a href="/admin/host(view)?/\?sort=[0-9]" '
-                'title="Sort by Name">Name</a>', output.data))
+                'title="Sort by Name">Name</a>', data))
             self.assertTrue(
-                '<a href="javascript:void(0)">List (3)</a>' in output.data)
+                '<a href="javascript:void(0)">List (3)</a>' in data)
 
     @patch('mirrormanager2.app.is_mirrormanager_admin')
     def test_admin_hostaclipview(self, login_func):
@@ -340,18 +353,19 @@ class FlaskUiAdminTest(tests.Modeltests):
         with tests.user_set(mirrormanager2.app.APP, user):
             output = self.handle_flask_admin_urls('/admin/hostaclip/')
             self.assertEqual(output.status_code, 200)
+            data = output.get_data(as_text=True)
             self.assertTrue(
                 '<title>Host - Host Acl Ip - Admin'
-                '</title>' in output.data)
+                '</title>' in data)
             self.assertTrue(re.search(
-                '<a href="/admin/arch(view)?/">Arch</a>', output.data))
+                '<a href="/admin/arch(view)?/">Arch</a>', data))
             self.assertTrue(re.search(
-                '<a href="/admin/category(view)?/">Category</a>', output.data))
+                '<a href="/admin/category(view)?/">Category</a>', data))
             self.assertTrue(re.search(
                 '<a href="/admin/hostaclip(view)?/\?sort=[01]" '
-                'title="Sort by Ip">Ip</a>', output.data))
+                'title="Sort by Ip">Ip</a>', data))
             self.assertTrue(
-                '<a href="javascript:void(0)">List (0)</a>' in output.data)
+                '<a href="javascript:void(0)">List (0)</a>' in data)
 
     @patch('mirrormanager2.app.is_mirrormanager_admin')
     def test_admin_hostcategoryview(self, login_func):
@@ -362,19 +376,20 @@ class FlaskUiAdminTest(tests.Modeltests):
         with tests.user_set(mirrormanager2.app.APP, user):
             output = self.handle_flask_admin_urls('/admin/hostcategory/')
             self.assertEqual(output.status_code, 200)
+            data = output.get_data(as_text=True)
             self.assertTrue(
                 '<title>Host - Host Category - Admin'
-                '</title>' in output.data)
+                '</title>' in data)
             self.assertTrue(re.search(
-                '<a href="/admin/arch(view)?/">Arch</a>', output.data))
+                '<a href="/admin/arch(view)?/">Arch</a>', data))
             self.assertTrue(re.search(
-                '<a href="/admin/category(view)?/">Category</a>', output.data))
+                '<a href="/admin/category(view)?/">Category</a>', data))
             self.assertTrue(re.search(
                 '<a href="/admin/hostcategory(view)?/\?sort=[02]" '
                 'title="Sort by Always Up2Date">Always Up2Date</a>',
-                output.data))
+                data))
             self.assertTrue(
-                '<a href="javascript:void(0)">List (4)</a>' in output.data)
+                '<a href="javascript:void(0)">List (4)</a>' in data)
 
     @patch('mirrormanager2.app.is_mirrormanager_admin')
     def test_admin_hostcategorydirview(self, login_func):
@@ -385,18 +400,19 @@ class FlaskUiAdminTest(tests.Modeltests):
         with tests.user_set(mirrormanager2.app.APP, user):
             output = self.handle_flask_admin_urls('/admin/hostcategorydir/')
             self.assertEqual(output.status_code, 200)
+            data = output.get_data(as_text=True)
             self.assertTrue(
                 '<title>Host - Host Category Dir - Admin'
-                '</title>' in output.data)
+                '</title>' in data)
             self.assertTrue(re.search(
-                '<a href="/admin/arch(view)?/">Arch</a>', output.data))
+                '<a href="/admin/arch(view)?/">Arch</a>', data))
             self.assertTrue(re.search(
-                '<a href="/admin/category(view)?/">Category</a>', output.data))
+                '<a href="/admin/category(view)?/">Category</a>', data))
             self.assertTrue(re.search(
                 '<a href="/admin/hostcategorydir(view)?/\?sort=[02]" '
-                'title="Sort by Path">Path</a>', output.data))
+                'title="Sort by Path">Path</a>', data))
             self.assertTrue(
-                '<a href="javascript:void(0)">List (2)</a>' in output.data)
+                '<a href="javascript:void(0)">List (2)</a>' in data)
 
     @patch('mirrormanager2.app.is_mirrormanager_admin')
     def test_admin_hostcategoryurlview(self, login_func):
@@ -407,18 +423,19 @@ class FlaskUiAdminTest(tests.Modeltests):
         with tests.user_set(mirrormanager2.app.APP, user):
             output = self.handle_flask_admin_urls('/admin/hostcategoryurl/')
             self.assertEqual(output.status_code, 200)
+            data = output.get_data(as_text=True)
             self.assertTrue(
                 '<title>Host - Host Category Url - Admin'
-                '</title>' in output.data)
+                '</title>' in data)
             self.assertTrue(re.search(
-                '<a href="/admin/arch(view)?/">Arch</a>', output.data))
+                '<a href="/admin/arch(view)?/">Arch</a>', data))
             self.assertTrue(re.search(
-                '<a href="/admin/category(view)?/">Category</a>', output.data))
+                '<a href="/admin/category(view)?/">Category</a>', data))
             self.assertTrue(re.search(
                 '<a href="/admin/hostcategoryurl(view)?/\?sort=[01]" '
-                'title="Sort by Url">Url</a>', output.data))
+                'title="Sort by Url">Url</a>', data))
             self.assertTrue(
-                '<a href="javascript:void(0)">List (8)</a>' in output.data)
+                '<a href="javascript:void(0)">List (8)</a>' in data)
 
     @patch('mirrormanager2.app.is_mirrormanager_admin')
     def test_admin_hostcountryview(self, login_func):
@@ -429,17 +446,18 @@ class FlaskUiAdminTest(tests.Modeltests):
         with tests.user_set(mirrormanager2.app.APP, user):
             output = self.handle_flask_admin_urls('/admin/hostcountry/')
             self.assertEqual(output.status_code, 200)
+            data = output.get_data(as_text=True)
             self.assertTrue(
                 '<title>Host - Host Country - Admin'
-                '</title>' in output.data)
+                '</title>' in data)
             self.assertTrue(re.search(
-                '<a href="/admin/arch(view)?/">Arch</a>', output.data))
+                '<a href="/admin/arch(view)?/">Arch</a>', data))
             self.assertTrue(re.search(
-                '<a href="/admin/category(view)?/">Category</a>', output.data))
+                '<a href="/admin/category(view)?/">Category</a>', data))
             self.assertEqual(
-                output.data.count('<th class="column-header">'), 2)
+                data.count('<th class="column-header">'), 2)
             self.assertTrue(
-                '<a href="javascript:void(0)">List (0)</a>' in output.data)
+                '<a href="javascript:void(0)">List (0)</a>' in data)
 
     @patch('mirrormanager2.app.is_mirrormanager_admin')
     def test_admin_hostcountryallowedview(self, login_func):
@@ -450,18 +468,19 @@ class FlaskUiAdminTest(tests.Modeltests):
         with tests.user_set(mirrormanager2.app.APP, user):
             output = self.handle_flask_admin_urls('/admin/hostcountryallowed/')
             self.assertEqual(output.status_code, 200)
+            data = output.get_data(as_text=True)
             self.assertTrue(
                 '<title>Host - Host Country Allowed - Admin'
-                '</title>' in output.data)
+                '</title>' in data)
             self.assertTrue(re.search(
-                '<a href="/admin/arch(view)?/">Arch</a>', output.data))
+                '<a href="/admin/arch(view)?/">Arch</a>', data))
             self.assertTrue(re.search(
-                '<a href="/admin/category(view)?/">Category</a>', output.data))
+                '<a href="/admin/category(view)?/">Category</a>', data))
             self.assertTrue(re.search(
                 '<a href="/admin/hostcountryallowed(view)?/\?sort=[01]" '
-                'title="Sort by Country">Country</a>', output.data))
+                'title="Sort by Country">Country</a>', data))
             self.assertTrue(
-                '<a href="javascript:void(0)">List (0)</a>' in output.data)
+                '<a href="javascript:void(0)">List (0)</a>' in data)
 
     @patch('mirrormanager2.app.is_mirrormanager_admin')
     def test_admin_hostlocationview(self, login_func):
@@ -472,17 +491,18 @@ class FlaskUiAdminTest(tests.Modeltests):
         with tests.user_set(mirrormanager2.app.APP, user):
             output = self.handle_flask_admin_urls('/admin/hostlocation/')
             self.assertEqual(output.status_code, 200)
+            data = output.get_data(as_text=True)
             self.assertTrue(
                 '<title>Host - Host Location - Admin'
-                '</title>' in output.data)
+                '</title>' in data)
             self.assertTrue(re.search(
-                '<a href="/admin/arch(view)?/">Arch</a>', output.data))
+                '<a href="/admin/arch(view)?/">Arch</a>', data))
             self.assertTrue(re.search(
-                '<a href="/admin/category(view)?/">Category</a>', output.data))
+                '<a href="/admin/category(view)?/">Category</a>', data))
             self.assertEqual(
-                output.data.count('<th class="column-header">'), 2)
+                data.count('<th class="column-header">'), 2)
             self.assertTrue(
-                '<a href="javascript:void(0)">List (0)</a>' in output.data)
+                '<a href="javascript:void(0)">List (0)</a>' in data)
 
     @patch('mirrormanager2.app.is_mirrormanager_admin')
     def test_admin_hostnetblockview(self, login_func):
@@ -493,18 +513,19 @@ class FlaskUiAdminTest(tests.Modeltests):
         with tests.user_set(mirrormanager2.app.APP, user):
             output = self.handle_flask_admin_urls('/admin/hostnetblock/')
             self.assertEqual(output.status_code, 200)
+            data = output.get_data(as_text=True)
             self.assertTrue(
                 '<title>Host - Host Netblock - Admin'
-                '</title>' in output.data)
+                '</title>' in data)
             self.assertTrue(re.search(
-                '<a href="/admin/arch(view)?/">Arch</a>', output.data))
+                '<a href="/admin/arch(view)?/">Arch</a>', data))
             self.assertTrue(re.search(
-                '<a href="/admin/category(view)?/">Category</a>', output.data))
+                '<a href="/admin/category(view)?/">Category</a>', data))
             self.assertTrue(re.search(
                 '<a href="/admin/hostnetblock(view)?/\?sort=[02]" '
-                'title="Sort by Name">Name</a>', output.data))
+                'title="Sort by Name">Name</a>', data))
             self.assertTrue(
-                '<a href="javascript:void(0)">List (0)</a>' in output.data)
+                '<a href="javascript:void(0)">List (0)</a>' in data)
 
     @patch('mirrormanager2.app.is_mirrormanager_admin')
     def test_admin_hostpeerasnview(self, login_func):
@@ -515,18 +536,19 @@ class FlaskUiAdminTest(tests.Modeltests):
         with tests.user_set(mirrormanager2.app.APP, user):
             output = self.handle_flask_admin_urls('/admin/hostpeerasn/')
             self.assertEqual(output.status_code, 200)
+            data = output.get_data(as_text=True)
             self.assertTrue(
                 '<title>Host - Host Peer Asn - Admin'
-                '</title>' in output.data)
+                '</title>' in data)
             self.assertTrue(re.search(
-                '<a href="/admin/arch(view)?/">Arch</a>', output.data))
+                '<a href="/admin/arch(view)?/">Arch</a>', data))
             self.assertTrue(re.search(
-                '<a href="/admin/category(view)?/">Category</a>', output.data))
+                '<a href="/admin/category(view)?/">Category</a>', data))
             self.assertTrue(re.search(
                 '<a href="/admin/hostpeerasn(view)?/\?sort=[02]" '
-                'title="Sort by Name">Name</a>', output.data))
+                'title="Sort by Name">Name</a>', data))
             self.assertTrue(
-                '<a href="javascript:void(0)">List (0)</a>' in output.data)
+                '<a href="javascript:void(0)">List (0)</a>' in data)
 
     @patch('mirrormanager2.app.is_mirrormanager_admin')
     def test_admin_hoststatsview(self, login_func):
@@ -537,18 +559,19 @@ class FlaskUiAdminTest(tests.Modeltests):
         with tests.user_set(mirrormanager2.app.APP, user):
             output = self.handle_flask_admin_urls('/admin/hoststats/')
             self.assertEqual(output.status_code, 200)
+            data = output.get_data(as_text=True)
             self.assertTrue(
                 '<title>Host - Host Stats - Admin'
-                '</title>' in output.data)
+                '</title>' in data)
             self.assertTrue(re.search(
-                '<a href="/admin/arch(view)?/">Arch</a>', output.data))
+                '<a href="/admin/arch(view)?/">Arch</a>', data))
             self.assertTrue(re.search(
-                '<a href="/admin/category(view)?/">Category</a>', output.data))
+                '<a href="/admin/category(view)?/">Category</a>', data))
             self.assertTrue(re.search(
                 '<a href="/admin/hoststats(view)?/\?sort=[02]" '
-                'title="Sort by Type">Type</a>', output.data))
+                'title="Sort by Type">Type</a>', data))
             self.assertTrue(
-                '<a href="javascript:void(0)">List (0)</a>' in output.data)
+                '<a href="javascript:void(0)">List (0)</a>' in data)
 
     @patch('mirrormanager2.app.is_mirrormanager_admin')
     def test_admin_locationview(self, login_func):
@@ -559,18 +582,19 @@ class FlaskUiAdminTest(tests.Modeltests):
         with tests.user_set(mirrormanager2.app.APP, user):
             output = self.handle_flask_admin_urls('/admin/location/')
             self.assertEqual(output.status_code, 200)
+            data = output.get_data(as_text=True)
             self.assertTrue(
                 '<title>Location - Admin'
-                '</title>' in output.data)
+                '</title>' in data)
             self.assertTrue(re.search(
-                '<a href="/admin/arch(view)?/">Arch</a>', output.data))
+                '<a href="/admin/arch(view)?/">Arch</a>', data))
             self.assertTrue(re.search(
-                '<a href="/admin/category(view)?/">Category</a>', output.data))
+                '<a href="/admin/category(view)?/">Category</a>', data))
             self.assertTrue(re.search(
                 '<a href="/admin/location(view)?/\?sort=0" '
-                'title="Sort by Name">Name</a>', output.data))
+                'title="Sort by Name">Name</a>', data))
             self.assertTrue(
-                '<a href="javascript:void(0)">List (3)</a>' in output.data)
+                '<a href="javascript:void(0)">List (3)</a>' in data)
 
     @patch('mirrormanager2.app.is_mirrormanager_admin')
     def test_admin_netblockcountryview(self, login_func):
@@ -581,18 +605,19 @@ class FlaskUiAdminTest(tests.Modeltests):
         with tests.user_set(mirrormanager2.app.APP, user):
             output = self.handle_flask_admin_urls('/admin/netblockcountry/')
             self.assertEqual(output.status_code, 200)
+            data = output.get_data(as_text=True)
             self.assertTrue(
                 '<title>Netblock Country - Admin'
-                '</title>' in output.data)
+                '</title>' in data)
             self.assertTrue(re.search(
-                '<a href="/admin/arch(view)?/">Arch</a>', output.data))
+                '<a href="/admin/arch(view)?/">Arch</a>', data))
             self.assertTrue(re.search(
-                '<a href="/admin/category(view)?/">Category</a>', output.data))
+                '<a href="/admin/category(view)?/">Category</a>', data))
             self.assertTrue(re.search(
                 '<a href="/admin/netblockcountry(view)?/\?sort=0" '
-                'title="Sort by Netblock">Netblock</a>', output.data))
+                'title="Sort by Netblock">Netblock</a>', data))
             self.assertTrue(
-                '<a href="javascript:void(0)">List (1)</a>' in output.data)
+                '<a href="javascript:void(0)">List (1)</a>' in data)
 
     @patch('mirrormanager2.app.is_mirrormanager_admin')
     def test_admin_productview(self, login_func):
@@ -603,18 +628,19 @@ class FlaskUiAdminTest(tests.Modeltests):
         with tests.user_set(mirrormanager2.app.APP, user):
             output = self.handle_flask_admin_urls('/admin/product/')
             self.assertEqual(output.status_code, 200)
+            data = output.get_data(as_text=True)
             self.assertTrue(
                 '<title>Product - Admin'
-                '</title>' in output.data)
+                '</title>' in data)
             self.assertTrue(re.search(
-                '<a href="/admin/arch(view)?/">Arch</a>', output.data))
+                '<a href="/admin/arch(view)?/">Arch</a>', data))
             self.assertTrue(re.search(
-                '<a href="/admin/category(view)?/">Category</a>', output.data))
+                '<a href="/admin/category(view)?/">Category</a>', data))
             self.assertTrue(re.search(
                 '<a href="/admin/product(view)?/\?sort=0" '
-                'title="Sort by Name">Name</a>', output.data))
+                'title="Sort by Name">Name</a>', data))
             self.assertTrue(
-                '<a href="javascript:void(0)">List (2)</a>' in output.data)
+                '<a href="javascript:void(0)">List (2)</a>' in data)
 
     @patch('mirrormanager2.app.is_mirrormanager_admin')
     def test_admin_repositoryview(self, login_func):
@@ -625,18 +651,19 @@ class FlaskUiAdminTest(tests.Modeltests):
         with tests.user_set(mirrormanager2.app.APP, user):
             output = self.handle_flask_admin_urls('/admin/repository/')
             self.assertEqual(output.status_code, 200)
+            data = output.get_data(as_text=True)
             self.assertTrue(
                 '<title>Repository - Repository - Admin'
-                '</title>' in output.data)
+                '</title>' in data)
             self.assertTrue(re.search(
-                '<a href="/admin/arch(view)?/">Arch</a>', output.data))
+                '<a href="/admin/arch(view)?/">Arch</a>', data))
             self.assertTrue(re.search(
-                '<a href="/admin/category(view)?/">Category</a>', output.data))
+                '<a href="/admin/category(view)?/">Category</a>', data))
             self.assertTrue(re.search(
                 '<a href="/admin/repository(view)?/\?sort=[0-4]" '
-                'title="Sort by Name">Name</a>', output.data))
+                'title="Sort by Name">Name</a>', data))
             self.assertTrue(
-                '<a href="javascript:void(0)">List (3)</a>' in output.data)
+                '<a href="javascript:void(0)">List (3)</a>' in data)
 
     @patch('mirrormanager2.app.is_mirrormanager_admin')
     def test_admin_repositoryredirectview(self, login_func):
@@ -647,18 +674,19 @@ class FlaskUiAdminTest(tests.Modeltests):
         with tests.user_set(mirrormanager2.app.APP, user):
             output = self.handle_flask_admin_urls('/admin/repositoryredirect/')
             self.assertEqual(output.status_code, 200)
+            data = output.get_data(as_text=True)
             self.assertTrue(
                 '<title>Repository - Repository Redirect - Admin'
-                '</title>' in output.data)
+                '</title>' in data)
             self.assertTrue(re.search(
-                '<a href="/admin/arch(view)?/">Arch</a>', output.data))
+                '<a href="/admin/arch(view)?/">Arch</a>', data))
             self.assertTrue(re.search(
-                '<a href="/admin/category(view)?/">Category</a>', output.data))
+                '<a href="/admin/category(view)?/">Category</a>', data))
             self.assertTrue(re.search(
                 '<a href="/admin/repositoryredirect(view)?/\?sort=0" '
-                'title="Sort by To Repo">To Repo</a>', output.data))
+                'title="Sort by To Repo">To Repo</a>', data))
             self.assertTrue(
-                '<a href="javascript:void(0)">List (3)</a>' in output.data)
+                '<a href="javascript:void(0)">List (3)</a>' in data)
 
     @patch('mirrormanager2.app.is_mirrormanager_admin')
     def test_admin_siteview(self, login_func):
@@ -669,18 +697,19 @@ class FlaskUiAdminTest(tests.Modeltests):
         with tests.user_set(mirrormanager2.app.APP, user):
             output = self.handle_flask_admin_urls('/admin/site/')
             self.assertEqual(output.status_code, 200)
+            data = output.get_data(as_text=True)
             self.assertTrue(
                 '<title>Site - Site - Admin'
-                '</title>' in output.data)
+                '</title>' in data)
             self.assertTrue(re.search(
-                '<a href="/admin/arch(view)?/">Arch</a>', output.data))
+                '<a href="/admin/arch(view)?/">Arch</a>', data))
             self.assertTrue(re.search(
-                '<a href="/admin/category(view)?/">Category</a>', output.data))
+                '<a href="/admin/category(view)?/">Category</a>', data))
             self.assertTrue(re.search(
                 '<a href="/admin/site(view)?/\?sort=0" '
-                'title="Sort by Name">Name</a>', output.data))
+                'title="Sort by Name">Name</a>', data))
             self.assertTrue(
-                '<a href="javascript:void(0)">List (3)</a>' in output.data)
+                '<a href="javascript:void(0)">List (3)</a>' in data)
 
     @patch('mirrormanager2.app.is_mirrormanager_admin')
     def test_admin_siteadminview(self, login_func):
@@ -691,18 +720,19 @@ class FlaskUiAdminTest(tests.Modeltests):
         with tests.user_set(mirrormanager2.app.APP, user):
             output = self.handle_flask_admin_urls('/admin/siteadmin/')
             self.assertEqual(output.status_code, 200)
+            data = output.get_data(as_text=True)
             self.assertTrue(
                 '<title>Site - Site Admin - Admin'
-                '</title>' in output.data)
+                '</title>' in data)
             self.assertTrue(re.search(
-                '<a href="/admin/arch(view)?/">Arch</a>', output.data))
+                '<a href="/admin/arch(view)?/">Arch</a>', data))
             self.assertTrue(re.search(
-                '<a href="/admin/category(view)?/">Category</a>', output.data))
+                '<a href="/admin/category(view)?/">Category</a>', data))
             self.assertTrue(re.search(
                 '<a href="/admin/siteadmin(view)?/\?sort=[01]" '
-                'title="Sort by Username">Username</a>', output.data))
+                'title="Sort by Username">Username</a>', data))
             self.assertTrue(
-                '<a href="javascript:void(0)">List (5)</a>' in output.data)
+                '<a href="javascript:void(0)">List (5)</a>' in data)
 
     @patch('mirrormanager2.app.is_mirrormanager_admin')
     def test_admin_sitetositeview(self, login_func):
@@ -713,18 +743,19 @@ class FlaskUiAdminTest(tests.Modeltests):
         with tests.user_set(mirrormanager2.app.APP, user):
             output = self.handle_flask_admin_urls('/admin/sitetosite/')
             self.assertEqual(output.status_code, 200)
+            data = output.get_data(as_text=True)
             self.assertTrue(
                 '<title>Site - Site To Site - Admin'
-                '</title>' in output.data)
+                '</title>' in data)
             self.assertTrue(re.search(
-                '<a href="/admin/arch(view)?/">Arch</a>', output.data))
+                '<a href="/admin/arch(view)?/">Arch</a>', data))
             self.assertTrue(re.search(
-                '<a href="/admin/category(view)?/">Category</a>', output.data))
+                '<a href="/admin/category(view)?/">Category</a>', data))
             self.assertTrue(re.search(
                 '<a href="/admin/sitetosite(view)?/\?sort=[0-2]" '
-                'title="Sort by Username">Username</a>', output.data))
+                'title="Sort by Username">Username</a>', data))
             self.assertTrue(
-                '<a href="javascript:void(0)">List (0)</a>' in output.data)
+                '<a href="javascript:void(0)">List (0)</a>' in data)
 
     @patch('mirrormanager2.app.is_mirrormanager_admin')
     def test_admin_versionview(self, login_func):
@@ -735,18 +766,19 @@ class FlaskUiAdminTest(tests.Modeltests):
         with tests.user_set(mirrormanager2.app.APP, user):
             output = self.handle_flask_admin_urls('/admin/version/')
             self.assertEqual(output.status_code, 200)
+            data = output.get_data(as_text=True)
             self.assertTrue(
                 '<title>Version - Admin'
-                '</title>' in output.data)
+                '</title>' in data)
             self.assertTrue(re.search(
-                '<a href="/admin/arch(view)?/">Arch</a>', output.data))
+                '<a href="/admin/arch(view)?/">Arch</a>', data))
             self.assertTrue(re.search(
-                '<a href="/admin/category(view)?/">Category</a>', output.data))
+                '<a href="/admin/category(view)?/">Category</a>', data))
             self.assertTrue(re.search(
                 '<a href="/admin/version(view)?/\?sort=[01]" '
-                'title="Sort by Name">Name</a>', output.data))
+                'title="Sort by Name">Name</a>', data))
             self.assertTrue(
-                '<a href="javascript:void(0)">List (6)</a>' in output.data)
+                '<a href="javascript:void(0)">List (6)</a>' in data)
 
 
 if __name__ == '__main__':

--- a/tests/test_ui_app.py
+++ b/tests/test_ui_app.py
@@ -64,163 +64,180 @@ class FlaskUiAppTest(tests.Modeltests):
 
         output = self.app.get('/')
         self.assertEqual(output.status_code, 200)
-        self.assertTrue('<title>Home - MirrorManager</title>' in output.data)
+        data = output.get_data(as_text=True)
+        self.assertTrue('<title>Home - MirrorManager</title>' in data)
         self.assertTrue(
-            '<a class="nav-link" href="/mirrors">Mirrors</a>' in output.data)
+            '<a class="nav-link" href="/mirrors">Mirrors</a>' in data)
         self.assertTrue(
             'href="/login?next=http://localhost/">Login</a>'
-            in output.data)
+            in data)
 
         user = tests.FakeFasUser()
         with tests.user_set(mirrormanager2.app.APP, user):
             output = self.app.get('/')
             self.assertEqual(output.status_code, 200)
+            data = output.get_data(as_text=True)
             self.assertTrue(
-                '<title>Home - MirrorManager</title>' in output.data)
+                '<title>Home - MirrorManager</title>' in data)
             self.assertTrue(
                 '<a class="nav-link" href="/mirrors">Mirrors</a>'
-                in output.data)
+                in data)
             self.assertFalse(
                 'href="/login?next=http://127.0.0.1:5000/">login/a>'
-                in output.data)
+                in data)
             self.assertTrue(
                 '<a class="dropdown-item" href="/site/mine">My Sites</a>'
-                in output.data)
+                in data)
             self.assertTrue(
                 'href="/logout?next=http://localhost/">Log Out</a>'
-                in output.data)
+                in data)
 
     def test_list_mirrors(self):
         """ Test the list_mirrors endpoint. """
         output = self.app.get('/mirrors')
         self.assertEqual(output.status_code, 200)
+        data = output.get_data(as_text=True)
         self.assertTrue(
-            '<title>Mirrors - MirrorManager</title>' in output.data)
+            '<title>Mirrors - MirrorManager</title>' in data)
         self.assertTrue(
-            '<h2>Public active mirrors</h2>' in output.data)
+            '<h2>Public active mirrors</h2>' in data)
         self.assertTrue(
-            'We have currently 2 active mirrors' in output.data)
+            'We have currently 2 active mirrors' in data)
 
         for i in [27, 26, 25]:
             output = self.app.get('/mirrors/Fedora/%s' % i)
             self.assertEqual(output.status_code, 200)
+            data = output.get_data(as_text=True)
             self.assertTrue(
-                '<title>Mirrors - MirrorManager</title>' in output.data)
+                '<title>Mirrors - MirrorManager</title>' in data)
             self.assertTrue(
                 '<a class="nav-link" href="/mirrors">Mirrors</a>'
-                in output.data)
+                in data)
             self.assertTrue(
-                'We have currently 2 active mirrors' in output.data)
+                'We have currently 2 active mirrors' in data)
 
             output = self.app.get('/mirrors/Fedora Linux/%s/x86_64' % i)
             self.assertEqual(output.status_code, 200)
+            data = output.get_data(as_text=True)
             self.assertTrue(
-                '<title>Mirrors - MirrorManager</title>' in output.data)
+                '<title>Mirrors - MirrorManager</title>' in data)
             self.assertTrue(
                 '<a class="nav-link" href="/mirrors">Mirrors</a>'
-                in output.data)
+                in data)
             self.assertTrue(
-                'We have currently 2 active mirrors' in output.data)
+                'We have currently 2 active mirrors' in data)
 
             output = self.app.get('/mirrors/Fedora Linux/20/i386')
             self.assertEqual(output.status_code, 200)
+            data = output.get_data(as_text=True)
             self.assertTrue(
-                '<title>Mirrors - MirrorManager</title>' in output.data)
+                '<title>Mirrors - MirrorManager</title>' in data)
             self.assertTrue(
                 '<a class="nav-link" href="/mirrors">Mirrors</a>'
-                in output.data)
+                in data)
             self.assertTrue(
                 'There are currently no active mirrors registered.'
-                in output.data)
+                in data)
 
     def test_mysite(self):
         """ Test the mysite endpoint. """
         output = self.app.get('/site/mine')
         self.assertEqual(output.status_code, 302)
+
         output = self.app.get('/site/mine', follow_redirects=True)
         self.assertEqual(output.status_code, 200)
+        data = output.get_data(as_text=True)
         if self.network_tests:
             self.assertTrue(
                 '<title>OpenID transaction in progress</title>'
-                in output.data)
+                in data)
 
         user = tests.FakeFasUser()
         with tests.user_set(mirrormanager2.app.APP, user):
             output = self.app.get('/site/mine')
             self.assertEqual(output.status_code, 200)
+            data = output.get_data(as_text=True)
             self.assertTrue(
-                'You have currently 1 sites listed' in output.data)
+                'You have currently 1 sites listed' in data)
 
     def test_all_sites(self):
         """ Test the all_sites endpoint. """
         output = self.app.get('/admin/all_sites')
         self.assertEqual(output.status_code, 302)
+
         output = self.app.get('/admin/all_sites', follow_redirects=True)
         self.assertEqual(output.status_code, 200)
+        data = output.get_data(as_text=True)
         if self.network_tests:
             self.assertTrue(
                 '<title>OpenID transaction in progress</title>'
-                in output.data)
+                in data)
 
         user = tests.FakeFasUser()
         with tests.user_set(mirrormanager2.app.APP, user):
             output = self.app.get('/admin/all_sites')
             self.assertEqual(output.status_code, 302)
+
             output = self.app.get('/admin/all_sites', follow_redirects=True)
             self.assertEqual(output.status_code, 200)
+            data = output.get_data(as_text=True)
             self.assertTrue(
-                '<li class="error">You are not an admin</li>' in output.data)
+                '<li class="error">You are not an admin</li>' in data)
             self.assertTrue(
-                '<title>Home - MirrorManager</title>' in output.data)
+                '<title>Home - MirrorManager</title>' in data)
             self.assertTrue(
                 '<a class="nav-link" href="/mirrors">Mirrors</a>'
-                in output.data)
+                in data)
 
         user = tests.FakeFasUserAdmin()
         with tests.user_set(mirrormanager2.app.APP, user):
             output = self.app.get('/admin/all_sites')
             self.assertEqual(output.status_code, 200)
+            data = output.get_data(as_text=True)
             self.assertTrue(
-                '<title>Home - MirrorManager</title>' in output.data)
+                '<title>Home - MirrorManager</title>' in data)
             self.assertTrue(
                 '<a class="nav-link" href="/mirrors">Mirrors</a>'
-                in output.data)
+                in data)
             self.assertTrue(
-                '<h2>Admin - List all sites</h2>' in output.data)
+                '<h2>Admin - List all sites</h2>' in data)
             self.assertTrue(
-                'You have currently 3 sites listed' in output.data)
+                'You have currently 3 sites listed' in data)
 
     def test_site_new(self):
         """ Test the site_new endpoint. """
         output = self.app.get('/site/new')
         self.assertEqual(output.status_code, 302)
+
         output = self.app.get('/site/new', follow_redirects=True)
         self.assertEqual(output.status_code, 200)
+        data = output.get_data(as_text=True)
         if self.network_tests:
             self.assertTrue(
                 '<title>OpenID transaction in progress</title>'
-                in output.data)
+                in data)
 
         user = tests.FakeFasUser()
         with tests.user_set(mirrormanager2.app.APP, user):
             output = self.app.get('/site/new')
             self.assertEqual(output.status_code, 200)
+            data = output.get_data(as_text=True)
             self.assertTrue(
                 '<title>New Site - MirrorManager</title>'
-                in output.data)
+                in data)
             self.assertTrue(
-                '<h2>Export Compliance</h2>' in output.data)
+                '<h2>Export Compliance</h2>' in data)
             self.assertTrue(
                 'td><label for="name">Site name</label></td>'
-                in output.data)
+                in data)
             self.assertTrue(
                 '<a class="nav-link" href="/mirrors">Mirrors</a>'
-                in output.data)
+                in data)
 
-            csrf_token = output.data.split(
+            csrf_token = data.split(
                 'name="csrf_token" type="hidden" value="')[1].split('">')[0]
 
-            data = {
+            post_data = {
                 'name': 'pingoured.fr',
                 'password': 'foobar',
                 'org_url': 'http://pingoured.fr',
@@ -230,81 +247,89 @@ class FlaskUiAppTest(tests.Modeltests):
 
             # Check CSRF protection
 
-            output = self.app.post('/site/new', data=data,
+            output = self.app.post('/site/new', data=post_data,
                                    follow_redirects=True)
             self.assertEqual(output.status_code, 200)
+            data = output.get_data(as_text=True)
             self.assertTrue(
-                '<title>New Site - MirrorManager</title>' in output.data)
+                '<title>New Site - MirrorManager</title>' in data)
             self.assertTrue(
-                '<h2>Export Compliance</h2>' in output.data)
+                '<h2>Export Compliance</h2>' in data)
             self.assertTrue(
-                'td><label for="name">Site name</label></td>' in output.data)
+                'td><label for="name">Site name</label></td>' in data)
             self.assertTrue(
                 '<a class="nav-link" href="/mirrors">Mirrors</a>'
-                in output.data)
+                in data)
 
             # Create the new site
 
-            data['csrf_token'] = csrf_token
+            post_data['csrf_token'] = csrf_token
 
-            output = self.app.post('/site/new', data=data,
+            output = self.app.post('/site/new', data=post_data,
                                    follow_redirects=True)
             self.assertEqual(output.status_code, 200)
+            data = output.get_data(as_text=True)
             self.assertTrue(
-                '<li class="message">Site added</li>' in output.data)
+                '<li class="message">Site added</li>' in data)
             self.assertTrue(
                 '<li class="message">pingou added as an admin</li>'
-                in output.data)
+                in data)
             self.assertTrue(
-                '<h2>Fedora Public Active Mirrors</h2>' in output.data)
+                '<h2>Fedora Public Active Mirrors</h2>' in data)
 
             output = self.app.get('/site/mine')
             self.assertEqual(output.status_code, 200)
+            data = output.get_data(as_text=True)
             self.assertTrue(
-                'You have currently 2 sites listed' in output.data)
+                'You have currently 2 sites listed' in data)
 
     def test_site_view(self):
         """ Test the site_view endpoint. """
         output = self.app.get('/site/2')
         self.assertEqual(output.status_code, 302)
+
         output = self.app.get('/site/2', follow_redirects=True)
 
         self.assertEqual(output.status_code, 200)
+        data = output.get_data(as_text=True)
         if self.network_tests:
             self.assertTrue(
                 '<title>OpenID transaction in progress</title>'
-                in output.data)
+                in data)
 
         user = tests.FakeFasUser()
         with tests.user_set(mirrormanager2.app.APP, user):
             output = self.app.get('/site/5')
             self.assertEqual(output.status_code, 404)
-            self.assertTrue('<p>Site not found</p>' in output.data)
+            data = output.get_data(as_text=True)
+            self.assertTrue('<p>Site not found</p>' in data)
 
             output = self.app.get('/site/2')
             self.assertEqual(output.status_code, 200)
+            data = output.get_data(as_text=True)
             self.assertTrue(
-                '<h2>Information site: test-mirror2</h2>' in output.data)
-            self.assertTrue('Created by: kevin' in output.data)
-            self.assertTrue('mirror2.localhost</a> <br />' in output.data)
+                '<h2>Information site: test-mirror2</h2>' in data)
+            self.assertTrue('Created by: kevin' in data)
+            self.assertTrue('mirror2.localhost</a> <br />' in data)
 
-            csrf_token = output.data.split(
+            csrf_token = data.split(
                 'name="csrf_token" type="hidden" value="')[1].split('">')[0]
 
             # Incomplete input
-            data = {
+            post_data = {
                 'name': 'test-mirror2.1',
             }
 
-            output = self.app.post('/site/2', data=data,
+            output = self.app.post('/site/2', data=post_data,
                                    follow_redirects=True)
             self.assertEqual(output.status_code, 200)
+            data = output.get_data(as_text=True)
             self.assertTrue(
-                '<h2>Information site: test-mirror2</h2>' in output.data)
-            self.assertTrue('Created by: kevin' in output.data)
-            self.assertEqual(output.data.count('field is required.'), 2)
+                '<h2>Information site: test-mirror2</h2>' in data)
+            self.assertTrue('Created by: kevin' in data)
+            self.assertEqual(data.count('field is required.'), 2)
 
-            data = {
+            post_data = {
                 'name': 'test-mirror2.1',
                 'password': 'test_password2',
                 'org_url': 'http://getfedora.org',
@@ -315,72 +340,80 @@ class FlaskUiAppTest(tests.Modeltests):
 
             # Check CSRF protection
 
-            output = self.app.post('/site/2', data=data,
+            output = self.app.post('/site/2', data=post_data,
                                    follow_redirects=True)
             self.assertEqual(output.status_code, 200)
+            data = output.get_data(as_text=True)
             self.assertTrue(
-                '<h2>Information site: test-mirror2</h2>' in output.data)
-            self.assertTrue('Created by: kevin' in output.data)
+                '<h2>Information site: test-mirror2</h2>' in data)
+            self.assertTrue('Created by: kevin' in data)
 
             # Update site
 
-            data['csrf_token'] = csrf_token
+            post_data['csrf_token'] = csrf_token
 
-            output = self.app.post('/site/2', data=data,
+            output = self.app.post('/site/2', data=post_data,
                                    follow_redirects=True)
             self.assertEqual(output.status_code, 200)
+            data = output.get_data(as_text=True)
             self.assertTrue(
-                '<h2>Fedora Public Active Mirrors</h2>' in output.data)
+                '<h2>Fedora Public Active Mirrors</h2>' in data)
             self.assertTrue(
-                '<li class="message">Site Updated</li>' in output.data)
+                '<li class="message">Site Updated</li>' in data)
 
             # Check after the edit
             output = self.app.get('/site/2')
             self.assertEqual(output.status_code, 200)
+            data = output.get_data(as_text=True)
             self.assertTrue(
-                '<h2>Information site: test-mirror2.1</h2>' in output.data)
-            self.assertTrue('Created by: kevin' in output.data)
-            self.assertTrue('mirror2.localhost</a> <br />' in output.data)
+                '<h2>Information site: test-mirror2.1</h2>' in data)
+            self.assertTrue('Created by: kevin' in data)
+            self.assertTrue('mirror2.localhost</a> <br />' in data)
 
     def test_host_new(self):
         """ Test the host_new endpoint. """
         output = self.app.get('/host/2/new')
         self.assertEqual(output.status_code, 302)
+
         output = self.app.get('/host/2/new', follow_redirects=True)
         self.assertEqual(output.status_code, 200)
+        data = output.get_data(as_text=True)
         if self.network_tests:
             self.assertTrue(
                 '<title>OpenID transaction in progress</title>'
-                in output.data)
+                in data)
 
         user = tests.FakeFasUser()
         with tests.user_set(mirrormanager2.app.APP, user):
             # Invalid site identifier
             output = self.app.get('/host/5/new')
             self.assertEqual(output.status_code, 404)
-            self.assertTrue('<p>Site not found</p>' in output.data)
+            data = output.get_data(as_text=True)
+            self.assertTrue('<p>Site not found</p>' in data)
 
             # Check before adding the host
             output = self.app.get('/site/2')
             self.assertEqual(output.status_code, 200)
+            data = output.get_data(as_text=True)
             self.assertTrue(
-                '<h2>Information site: test-mirror2</h2>' in output.data)
-            self.assertTrue('Created by: kevin' in output.data)
-            self.assertTrue('mirror2.localhost</a> <br />' in output.data)
-            self.assertFalse('pingoured.fr</a> <br />' in output.data)
+                '<h2>Information site: test-mirror2</h2>' in data)
+            self.assertTrue('Created by: kevin' in data)
+            self.assertTrue('mirror2.localhost</a> <br />' in data)
+            self.assertFalse('pingoured.fr</a> <br />' in data)
 
             # Test host_new
             output = self.app.get('/host/2/new')
             self.assertEqual(output.status_code, 200)
+            data = output.get_data(as_text=True)
             self.assertTrue(
-                '<title>New Host - MirrorManager</title>' in output.data)
+                '<title>New Host - MirrorManager</title>' in data)
             self.assertTrue(
-                '<h2>Create new host</h2>' in output.data)
+                '<h2>Create new host</h2>' in data)
 
-            csrf_token = output.data.split(
+            csrf_token = data.split(
                 'name="csrf_token" type="hidden" value="')[1].split('">')[0]
 
-            data = {
+            post_data = {
                 'name': 'pingoured.fr',
                 'admin_active': True,
                 'user_active': True,
@@ -392,117 +425,129 @@ class FlaskUiAppTest(tests.Modeltests):
 
             # Check CSRF protection
 
-            output = self.app.post('/host/2/new', data=data,
+            output = self.app.post('/host/2/new', data=post_data,
                                    follow_redirects=True)
             self.assertEqual(output.status_code, 200)
+            data = output.get_data(as_text=True)
             self.assertTrue(
-                '<title>New Host - MirrorManager</title>' in output.data)
+                '<title>New Host - MirrorManager</title>' in data)
             self.assertTrue(
-                '<h2>Create new host</h2>' in output.data)
+                '<h2>Create new host</h2>' in data)
 
             # Create Host
 
-            data['csrf_token'] = csrf_token
+            post_data['csrf_token'] = csrf_token
 
-            output = self.app.post('/host/2/new', data=data,
+            output = self.app.post('/host/2/new', data=post_data,
                                    follow_redirects=True)
             self.assertEqual(output.status_code, 200)
+            data = output.get_data(as_text=True)
             self.assertTrue(
-                '<li class="message">Host added</li>' in output.data)
+                '<li class="message">Host added</li>' in data)
             self.assertTrue(
-                '<h2>Information site: test-mirror2</h2>' in output.data)
-            self.assertTrue('Created by: kevin' in output.data)
-            self.assertTrue('mirror2.localhost</a> <br />' in output.data)
-            self.assertTrue('pingoured.fr</a> <br />' in output.data)
+                '<h2>Information site: test-mirror2</h2>' in data)
+            self.assertTrue('Created by: kevin' in data)
+            self.assertTrue('mirror2.localhost</a> <br />' in data)
+            self.assertTrue('pingoured.fr</a> <br />' in data)
 
             # Try creating the same host -- will fail
-            output = self.app.post('/host/2/new', data=data,
+            output = self.app.post('/host/2/new', data=post_data,
                                    follow_redirects=True)
             self.assertEqual(output.status_code, 200)
+            data = output.get_data(as_text=True)
             self.assertTrue(
                 '<li class="message">Could not create the new host</li>'
-                in output.data)
+                in data)
 
     def test_siteadmin_new(self):
         """ Test the siteadmin_new endpoint. """
         output = self.app.get('/site/2/admin/new')
         self.assertEqual(output.status_code, 302)
+
         output = self.app.get('/site/2/admin/new', follow_redirects=True)
         self.assertEqual(output.status_code, 200)
+        data = output.get_data(as_text=True)
         if self.network_tests:
             self.assertTrue(
                 '<title>OpenID transaction in progress</title>'
-                in output.data)
+                in data)
 
         user = tests.FakeFasUser()
         with tests.user_set(mirrormanager2.app.APP, user):
             # Invalid site identifier
             output = self.app.get('/site/5/admin/new')
             self.assertEqual(output.status_code, 404)
-            self.assertTrue('<p>Site not found</p>' in output.data)
+            data = output.get_data(as_text=True)
+            self.assertTrue('<p>Site not found</p>' in data)
 
             # Check before adding the host
             output = self.app.get('/site/2')
             self.assertEqual(output.status_code, 200)
+            data = output.get_data(as_text=True)
             self.assertTrue(
-                '<h2>Information site: test-mirror2</h2>' in output.data)
-            self.assertTrue('Created by: kevin' in output.data)
+                '<h2>Information site: test-mirror2</h2>' in data)
+            self.assertTrue('Created by: kevin' in data)
             self.assertFalse(
-                'action="/site/2/admin/5/delete">' in output.data)
-            self.assertFalse('skvidal' in output.data)
+                'action="/site/2/admin/5/delete">' in data)
+            self.assertFalse('skvidal' in data)
 
             # Test host_new
             output = self.app.get('/site/2/admin/new')
             self.assertEqual(output.status_code, 200)
+            data = output.get_data(as_text=True)
             self.assertTrue(
-                '<title>New Site Admin - MirrorManager</title>' in output.data)
+                '<title>New Site Admin - MirrorManager</title>' in data)
             self.assertTrue(
                 '<h2>Add Site admin to site: test-mirror2</h2>'
-                in output.data)
+                in data)
 
-            csrf_token = output.data.split(
+            csrf_token = data.split(
                 'name="csrf_token" type="hidden" value="')[1].split('">')[0]
 
-            data = {
+            post_data = {
                 'username': 'skvidal',
             }
 
             # Check CSRF protection
 
-            output = self.app.post('/site/2/admin/new', data=data,
+            output = self.app.post('/site/2/admin/new', data=post_data,
                                    follow_redirects=True)
             self.assertEqual(output.status_code, 200)
+            data = output.get_data(as_text=True)
             self.assertTrue(
-                '<title>New Site Admin - MirrorManager</title>' in output.data)
+                '<title>New Site Admin - MirrorManager</title>' in data)
             self.assertTrue(
                 '<h2>Add Site admin to site: test-mirror2</h2>'
-                in output.data)
+                in data)
 
             # Create Admin
 
-            data['csrf_token'] = csrf_token
+            post_data['csrf_token'] = csrf_token
 
-            output = self.app.post('/site/2/admin/new', data=data,
+            output = self.app.post('/site/2/admin/new', data=post_data,
                                    follow_redirects=True)
             self.assertEqual(output.status_code, 200)
+            data = output.get_data(as_text=True)
             self.assertTrue(
-                '<li class="message">Site Admin added</li>' in output.data)
+                '<li class="message">Site Admin added</li>' in data)
             self.assertTrue(
-                '<h2>Information site: test-mirror2</h2>' in output.data)
-            self.assertTrue('Created by: kevin' in output.data)
-            self.assertTrue('action="/site/2/admin/3/delete">' in output.data)
-            self.assertTrue('skvidal' in output.data)
+                '<h2>Information site: test-mirror2</h2>' in data)
+            self.assertTrue('Created by: kevin' in data)
+            self.assertTrue('action="/site/2/admin/3/delete">' in data)
+            self.assertTrue('skvidal' in data)
 
     def test_siteadmin_delete(self):
         """ Test the siteadmin_delete endpoint. """
         output = self.app.post('/site/2/admin/3/delete')
         self.assertEqual(output.status_code, 302)
+
         output = self.app.post('/site/2/admin/3/delete', follow_redirects=True)
         self.assertEqual(output.status_code, 200)
+        data = output.get_data(as_text=True)
         if self.network_tests:
             self.assertTrue(
                 '<title>OpenID transaction in progress</title>'
-                in output.data)
+                in data)
 
         user = tests.FakeFasUser()
         with tests.user_set(mirrormanager2.app.APP, user):
@@ -510,113 +555,124 @@ class FlaskUiAppTest(tests.Modeltests):
             # Check before adding the host
             output = self.app.get('/site/2')
             self.assertEqual(output.status_code, 200)
+            data = output.get_data(as_text=True)
             self.assertTrue(
-                '<h2>Information site: test-mirror2</h2>' in output.data)
-            self.assertTrue('Created by: kevin' in output.data)
+                '<h2>Information site: test-mirror2</h2>' in data)
+            self.assertTrue('Created by: kevin' in data)
             self.assertTrue(
-                'action="/site/2/admin/3/delete">' in output.data)
-            self.assertEqual(output.data.count('ralph'), 1)
+                'action="/site/2/admin/3/delete">' in data)
+            self.assertEqual(data.count('ralph'), 1)
 
-            csrf_token = output.data.split(
+            csrf_token = data.split(
                 'name="csrf_token" type="hidden" value="')[1].split('">')[0]
 
-            data = {}
+            post_data = {}
 
             # Check CSRF protection
 
-            output = self.app.post('/site/2/admin/3/delete', data=data,
+            output = self.app.post('/site/2/admin/3/delete', data=post_data,
                                    follow_redirects=True)
             self.assertEqual(output.status_code, 200)
+            data = output.get_data(as_text=True)
             self.assertTrue(
-                '<h2>Information site: test-mirror2</h2>' in output.data)
-            self.assertTrue('Created by: kevin' in output.data)
+                '<h2>Information site: test-mirror2</h2>' in data)
+            self.assertTrue('Created by: kevin' in data)
             self.assertTrue(
-                'action="/site/2/admin/3/delete">' in output.data)
-            self.assertEqual(output.data.count('ralph'), 1)
+                'action="/site/2/admin/3/delete">' in data)
+            self.assertEqual(data.count('ralph'), 1)
 
             # Delete Site Admin
 
-            data['csrf_token'] = csrf_token
+            post_data['csrf_token'] = csrf_token
 
             # Invalid site identifier
-            output = self.app.post('/site/5/admin/3/delete', data=data,
+            output = self.app.post('/site/5/admin/3/delete', data=post_data,
                                    follow_redirects=True)
             self.assertEqual(output.status_code, 404)
-            self.assertTrue('<p>Site not found</p>' in output.data)
+            data = output.get_data(as_text=True)
+            self.assertTrue('<p>Site not found</p>' in data)
 
             # Invalid site admin identifier
-            output = self.app.post('/site/2/admin/9/delete', data=data,
+            output = self.app.post('/site/2/admin/9/delete', data=post_data,
                                    follow_redirects=True)
             self.assertEqual(output.status_code, 404)
-            self.assertTrue('<p>Site Admin not found</p>' in output.data)
+            data = output.get_data(as_text=True)
+            self.assertTrue('<p>Site Admin not found</p>' in data)
 
             # Valid site admin but not for this site
-            output = self.app.post('/site/2/admin/1/delete', data=data,
+            output = self.app.post('/site/2/admin/1/delete', data=post_data,
                                    follow_redirects=True)
             self.assertEqual(output.status_code, 404)
+            data = output.get_data(as_text=True)
             self.assertTrue(
-                '<p>Site Admin not related to this Site</p>' in output.data)
+                '<p>Site Admin not related to this Site</p>' in data)
 
             # Delete Site Admin
-            output = self.app.post('/site/2/admin/3/delete', data=data,
+            output = self.app.post('/site/2/admin/3/delete', data=post_data,
                                    follow_redirects=True)
             self.assertEqual(output.status_code, 200)
+            data = output.get_data(as_text=True)
             self.assertTrue(
-                '<h2>Information site: test-mirror2</h2>' in output.data)
-            self.assertTrue('Created by: kevin' in output.data)
+                '<h2>Information site: test-mirror2</h2>' in data)
+            self.assertTrue('Created by: kevin' in data)
             self.assertFalse(
-                'action="/site/2/admin/3/delete">' in output.data)
-            self.assertEqual(output.data.count('ralph'), 0)
+                'action="/site/2/admin/3/delete">' in data)
+            self.assertEqual(data.count('ralph'), 0)
 
             # Trying to delete the only admin
-            output = self.app.post('/site/2/admin/4/delete', data=data,
+            output = self.app.post('/site/2/admin/4/delete', data=post_data,
                                    follow_redirects=True)
             self.assertEqual(output.status_code, 200)
+            data = output.get_data(as_text=True)
             self.assertTrue(
                 '<li class="error">There is only one admin set, you cannot '
-                'delete it.</li>' in output.data)
+                'delete it.</li>' in data)
 
     def test_host_view(self):
         """ Test the host_view endpoint. """
         output = self.app.get('/host/5')
         self.assertEqual(output.status_code, 302)
-        output = self.app.get('/host/5', follow_redirects=True)
 
+        output = self.app.get('/host/5', follow_redirects=True)
         self.assertEqual(output.status_code, 200)
+        data = output.get_data(as_text=True)
         if self.network_tests:
             self.assertTrue(
                 '<title>OpenID transaction in progress</title>'
-                in output.data)
+                in data)
 
         user = tests.FakeFasUser()
         with tests.user_set(mirrormanager2.app.APP, user):
             output = self.app.get('/host/50')
             self.assertEqual(output.status_code, 404)
-            self.assertTrue('<p>Host not found</p>' in output.data)
+            data = output.get_data(as_text=True)
+            self.assertTrue('<p>Host not found</p>' in data)
 
             output = self.app.get('/host/3')
             self.assertEqual(output.status_code, 200)
+            data = output.get_data(as_text=True)
             self.assertTrue(
-                '<h2>Host private.localhost' in output.data)
-            self.assertTrue('Back to <a href="/site/1">' in output.data)
+                '<h2>Host private.localhost' in data)
+            self.assertTrue('Back to <a href="/site/1">' in data)
 
-            csrf_token = output.data.split(
+            csrf_token = data.split(
                 'name="csrf_token" type="hidden" value="')[1].split('">')[0]
 
             # Incomplete input
-            data = {
+            post_data = {
                 'name': 'private.localhost.1',
             }
 
-            output = self.app.post('/host/3', data=data,
+            output = self.app.post('/host/3', data=post_data,
                                    follow_redirects=True)
             self.assertEqual(output.status_code, 200)
+            data = output.get_data(as_text=True)
             self.assertTrue(
-                '<h2>Host private.localhost' in output.data)
-            self.assertTrue('Back to <a href="/site/1">' in output.data)
-            self.assertEqual(output.data.count('field is required.'), 3)
+                '<h2>Host private.localhost' in data)
+            self.assertTrue('Back to <a href="/site/1">' in data)
+            self.assertEqual(data.count('field is required.'), 3)
 
-            data = {
+            post_data = {
                 'name': 'private.localhost.1',
                 'admin_active': True,
                 'user_active': True,
@@ -629,102 +685,111 @@ class FlaskUiAppTest(tests.Modeltests):
 
             # Check CSRF protection
 
-            output = self.app.post('/host/3', data=data,
+            output = self.app.post('/host/3', data=post_data,
                                    follow_redirects=True)
             self.assertEqual(output.status_code, 200)
+            data = output.get_data(as_text=True)
             self.assertTrue(
-                '<h2>Host private.localhost' in output.data)
-            self.assertTrue('Back to <a href="/site/1">' in output.data)
+                '<h2>Host private.localhost' in data)
+            self.assertTrue('Back to <a href="/site/1">' in data)
 
             # Update site
 
-            data['csrf_token'] = csrf_token
+            post_data['csrf_token'] = csrf_token
 
-            output = self.app.post('/host/3', data=data,
+            output = self.app.post('/host/3', data=post_data,
                                    follow_redirects=True)
             self.assertEqual(output.status_code, 200)
+            data = output.get_data(as_text=True)
             self.assertTrue(
-                '<h2>Host private.localhost.1' in output.data)
-            self.assertTrue('Back to <a href="/site/1">' in output.data)
+                '<h2>Host private.localhost.1' in data)
+            self.assertTrue('Back to <a href="/site/1">' in data)
 
     def test_host_netblock_new(self):
         """ Test the host_netblock_new endpoint. """
         output = self.app.get('/host/3/netblock/new')
         self.assertEqual(output.status_code, 302)
-        output = self.app.get('/host/3/netblock/new', follow_redirects=True)
 
+        output = self.app.get('/host/3/netblock/new', follow_redirects=True)
         self.assertEqual(output.status_code, 200)
+        data = output.get_data(as_text=True)
         if self.network_tests:
             self.assertTrue(
                 '<title>OpenID transaction in progress</title>'
-                in output.data)
+                in data)
 
         user = tests.AnotherFakeFasUser()
         with tests.user_set(mirrormanager2.app.APP, user):
             output = self.app.get('/host/50/netblock/new')
             self.assertEqual(output.status_code, 404)
-            self.assertTrue('<p>Host not found</p>' in output.data)
+            data = output.get_data(as_text=True)
+            self.assertTrue('<p>Host not found</p>' in data)
 
             output = self.app.get('/host/3/netblock/new')
             self.assertEqual(output.status_code, 200)
+            data = output.get_data(as_text=True)
             self.assertTrue(
-                '<h2>Add host netblock</h2>' in output.data)
-            self.assertTrue('Back to <a href="/host/3">' in output.data)
+                '<h2>Add host netblock</h2>' in data)
+            self.assertTrue('Back to <a href="/host/3">' in data)
             self.assertTrue(
                 '<title>New Host netblock - MirrorManager</title>'
-                in output.data)
+                in data)
             self.assertFalse(
-                'action="/host/3/host_netblock/2/delete">' in output.data)
+                'action="/host/3/host_netblock/2/delete">' in data)
 
-            csrf_token = output.data.split(
+            csrf_token = data.split(
                 'name="csrf_token" type="hidden" value="')[1].split('">')[0]
 
-            data = {
+            post_data = {
                 'netblock': '192.168.0.0/24',
                 'name': 'home network',
             }
 
             # Check CSRF protection
 
-            output = self.app.post('/host/3/netblock/new', data=data,
+            output = self.app.post('/host/3/netblock/new', data=post_data,
                                    follow_redirects=True)
             self.assertEqual(output.status_code, 200)
+            data = output.get_data(as_text=True)
             self.assertTrue(
-                '<h2>Add host netblock</h2>' in output.data)
-            self.assertTrue('Back to <a href="/host/3">' in output.data)
+                '<h2>Add host netblock</h2>' in data)
+            self.assertTrue('Back to <a href="/host/3">' in data)
             self.assertTrue(
                 '<title>New Host netblock - MirrorManager</title>'
-                in output.data)
+                in data)
             self.assertFalse(
-                'action="/host/3/host_netblock/1/delete">' in output.data)
+                'action="/host/3/host_netblock/1/delete">' in data)
 
             # Update site
 
-            data['csrf_token'] = csrf_token
+            post_data['csrf_token'] = csrf_token
 
-            output = self.app.post('/host/3/netblock/new', data=data,
+            output = self.app.post('/host/3/netblock/new', data=post_data,
                                    follow_redirects=True)
             self.assertEqual(output.status_code, 200)
+            data = output.get_data(as_text=True)
             self.assertTrue(
-                '<li class="message">Host netblock added</li>' in output.data)
-            self.assertTrue('<h2>Host private.localhost' in output.data)
-            self.assertTrue('Back to <a href="/site/1">' in output.data)
+                '<li class="message">Host netblock added</li>' in data)
+            self.assertTrue('<h2>Host private.localhost' in data)
+            self.assertTrue('Back to <a href="/site/1">' in data)
             self.assertTrue(
-                '<title>Host - MirrorManager</title>' in output.data)
+                '<title>Host - MirrorManager</title>' in data)
             self.assertTrue(
-                'action="/host/3/host_netblock/2/delete">' in output.data)
+                'action="/host/3/host_netblock/2/delete">' in data)
 
     def test_host_netblock_delete(self):
         """ Test the host_netblock_delete endpoint. """
         output = self.app.post('/host/3/host_netblock/1/delete')
         self.assertEqual(output.status_code, 302)
+
         output = self.app.post(
             '/host/3/host_netblock/1/delete', follow_redirects=True)
         self.assertEqual(output.status_code, 200)
+        data = output.get_data(as_text=True)
         if self.network_tests:
             self.assertTrue(
                 '<title>OpenID transaction in progress</title>'
-                in output.data)
+                in data)
 
         user = tests.AnotherFakeFasUser()
         with tests.user_set(mirrormanager2.app.APP, user):
@@ -732,142 +797,154 @@ class FlaskUiAppTest(tests.Modeltests):
             # Check before adding the host
             output = self.app.get('/host/3')
             self.assertEqual(output.status_code, 200)
-            self.assertTrue('<h2>Host private.localhost' in output.data)
-            self.assertTrue('Back to <a href="/site/1">' in output.data)
+            data = output.get_data(as_text=True)
+            self.assertTrue('<h2>Host private.localhost' in data)
+            self.assertTrue('Back to <a href="/site/1">' in data)
             self.assertTrue(
-                '<title>Host - MirrorManager</title>' in output.data)
+                '<title>Host - MirrorManager</title>' in data)
             self.assertTrue(
-                'action="/host/3/host_netblock/1/delete">' in output.data)
+                'action="/host/3/host_netblock/1/delete">' in data)
 
-            csrf_token = output.data.split(
+            csrf_token = data.split(
                 'name="csrf_token" type="hidden" value="')[1].split('">')[0]
 
-            data = {}
+            post_data = {}
 
             # Check CSRF protection
 
             output = self.app.post(
-                '/host/3/host_netblock/1/delete', data=data,
+                '/host/3/host_netblock/1/delete', data=post_data,
                 follow_redirects=True)
             self.assertEqual(output.status_code, 200)
-            self.assertTrue('<h2>Host private.localhost' in output.data)
-            self.assertTrue('Back to <a href="/site/1">' in output.data)
+            data = output.get_data(as_text=True)
+            self.assertTrue('<h2>Host private.localhost' in data)
+            self.assertTrue('Back to <a href="/site/1">' in data)
             self.assertTrue(
-                '<title>Host - MirrorManager</title>' in output.data)
+                '<title>Host - MirrorManager</title>' in data)
             self.assertTrue(
-                'action="/host/3/host_netblock/1/delete">' in output.data)
+                'action="/host/3/host_netblock/1/delete">' in data)
 
             # Delete Site Admin
 
-            data['csrf_token'] = csrf_token
+            post_data['csrf_token'] = csrf_token
 
             # Invalid site identifier
             output = self.app.post(
-                '/host/5/host_netblock/1/delete', data=data,
+                '/host/5/host_netblock/1/delete', data=post_data,
                 follow_redirects=True)
             self.assertEqual(output.status_code, 404)
-            self.assertTrue('<p>Host not found</p>' in output.data)
+            data = output.get_data(as_text=True)
+            self.assertTrue('<p>Host not found</p>' in data)
 
             # Invalid site admin identifier
             output = self.app.post(
-                '/host/3/host_netblock/2/delete', data=data,
+                '/host/3/host_netblock/2/delete', data=post_data,
                 follow_redirects=True)
             self.assertEqual(output.status_code, 404)
-            self.assertTrue('<p>Host netblock not found</p>' in output.data)
+            data = output.get_data(as_text=True)
+            self.assertTrue('<p>Host netblock not found</p>' in data)
 
             # Delete Site Admin
             output = self.app.post(
-                '/host/3/host_netblock/1/delete', data=data,
+                '/host/3/host_netblock/1/delete', data=post_data,
                 follow_redirects=True)
             self.assertEqual(output.status_code, 200)
+            data = output.get_data(as_text=True)
             self.assertTrue(
                 '<li class="message">Host netblock deleted</li>'
-                in output.data)
-            self.assertTrue('<h2>Host private.localhost' in output.data)
-            self.assertTrue('Back to <a href="/site/1">' in output.data)
+                in data)
+            self.assertTrue('<h2>Host private.localhost' in data)
+            self.assertTrue('Back to <a href="/site/1">' in data)
             self.assertTrue(
-                '<title>Host - MirrorManager</title>' in output.data)
+                '<title>Host - MirrorManager</title>' in data)
             self.assertFalse(
-                'action="/host/3/host_netblock/1/delete">' in output.data)
+                'action="/host/3/host_netblock/1/delete">' in data)
 
     def test_host_asn_new(self):
         """ Test the host_asn_new endpoint. """
         output = self.app.get('/host/3/asn/new')
         self.assertEqual(output.status_code, 302)
-        output = self.app.get('/host/3/asn/new', follow_redirects=True)
 
+        output = self.app.get('/host/3/asn/new', follow_redirects=True)
         self.assertEqual(output.status_code, 200)
+        data = output.get_data(as_text=True)
         if self.network_tests:
             self.assertTrue(
                 '<title>OpenID transaction in progress</title>'
-                in output.data)
+                in data)
 
         user = tests.FakeFasUserAdmin()
         with tests.user_set(mirrormanager2.app.APP, user):
             output = self.app.get('/host/50/asn/new')
             self.assertEqual(output.status_code, 404)
-            self.assertTrue('<p>Host not found</p>' in output.data)
+            data = output.get_data(as_text=True)
+            self.assertTrue('<p>Host not found</p>' in data)
 
             output = self.app.get('/host/3/asn/new')
             self.assertEqual(output.status_code, 200)
+            data = output.get_data(as_text=True)
             self.assertTrue(
-                '<h2>Add host Peer ASNs</h2>' in output.data)
-            self.assertTrue('Back to <a href="/host/3">' in output.data)
+                '<h2>Add host Peer ASNs</h2>' in data)
+            self.assertTrue('Back to <a href="/host/3">' in data)
             self.assertTrue(
                 '<title>New Host Peer ASN - MirrorManager</title>'
-                in output.data)
+                in data)
             self.assertFalse(
-                'action="/host/3/host_asn/2/delete">' in output.data)
+                'action="/host/3/host_asn/2/delete">' in data)
 
-            csrf_token = output.data.split(
+            csrf_token = data.split(
                 'name="csrf_token" type="hidden" value="')[1].split('">')[0]
 
-            data = {
+            post_data = {
                 'asn': '192168',
                 'name': 'ASN pingoured',
             }
 
             # Check CSRF protection
 
-            output = self.app.post('/host/3/asn/new', data=data,
+            output = self.app.post('/host/3/asn/new', data=post_data,
                                    follow_redirects=True)
             self.assertEqual(output.status_code, 200)
+            data = output.get_data(as_text=True)
             self.assertTrue(
-                '<h2>Add host Peer ASNs</h2>' in output.data)
-            self.assertTrue('Back to <a href="/host/3">' in output.data)
+                '<h2>Add host Peer ASNs</h2>' in data)
+            self.assertTrue('Back to <a href="/host/3">' in data)
             self.assertTrue(
                 '<title>New Host Peer ASN - MirrorManager</title>'
-                in output.data)
+                in data)
             self.assertFalse(
-                'action="/host/3/host_asn/2/delete">' in output.data)
+                'action="/host/3/host_asn/2/delete">' in data)
 
             # Update site
 
-            data['csrf_token'] = csrf_token
+            post_data['csrf_token'] = csrf_token
 
-            output = self.app.post('/host/3/asn/new', data=data,
+            output = self.app.post('/host/3/asn/new', data=post_data,
                                    follow_redirects=True)
             self.assertEqual(output.status_code, 200)
+            data = output.get_data(as_text=True)
             self.assertTrue(
-                '<li class="message">Host Peer ASN added</li>' in output.data)
-            self.assertTrue('<h2>Host private.localhost' in output.data)
-            self.assertTrue('Back to <a href="/site/1">' in output.data)
+                '<li class="message">Host Peer ASN added</li>' in data)
+            self.assertTrue('<h2>Host private.localhost' in data)
+            self.assertTrue('Back to <a href="/site/1">' in data)
             self.assertTrue(
-                '<title>Host - MirrorManager</title>' in output.data)
+                '<title>Host - MirrorManager</title>' in data)
             self.assertTrue(
-                'action="/host/3/host_asn/2/delete">' in output.data)
+                'action="/host/3/host_asn/2/delete">' in data)
 
     def test_host_asn_delete(self):
         """ Test the host_asn_delete endpoint. """
         output = self.app.post('/host/3/host_asn/1/delete')
         self.assertEqual(output.status_code, 302)
+
         output = self.app.post(
             '/host/3/host_asn/1/delete', follow_redirects=True)
         self.assertEqual(output.status_code, 200)
+        data = output.get_data(as_text=True)
         if self.network_tests:
             self.assertTrue(
                 '<title>OpenID transaction in progress</title>'
-                in output.data)
+                in data)
 
         user = tests.FakeFasUserAdmin()
         with tests.user_set(mirrormanager2.app.APP, user):
@@ -875,157 +952,170 @@ class FlaskUiAppTest(tests.Modeltests):
             # Check before adding the host
             output = self.app.get('/host/3')
             self.assertEqual(output.status_code, 200)
-            self.assertTrue('<h2>Host private.localhost' in output.data)
-            self.assertTrue('Back to <a href="/site/1">' in output.data)
+            data = output.get_data(as_text=True)
+            self.assertTrue('<h2>Host private.localhost' in data)
+            self.assertTrue('Back to <a href="/site/1">' in data)
             self.assertTrue(
-                '<title>Host - MirrorManager</title>' in output.data)
+                '<title>Host - MirrorManager</title>' in data)
             self.assertTrue(
-                'action="/host/3/host_asn/1/delete">' in output.data)
+                'action="/host/3/host_asn/1/delete">' in data)
 
-            csrf_token = output.data.split(
+            csrf_token = data.split(
                 'name="csrf_token" type="hidden" value="')[1].split('">')[0]
 
-            data = {}
+            post_data = {}
 
             # Check CSRF protection
 
-            output = self.app.post('/host/3/host_asn/1/delete', data=data,
+            output = self.app.post('/host/3/host_asn/1/delete', data=post_data,
                                    follow_redirects=True)
             self.assertEqual(output.status_code, 200)
-            self.assertTrue('<h2>Host private.localhost' in output.data)
-            self.assertTrue('Back to <a href="/site/1">' in output.data)
+            data = output.get_data(as_text=True)
+            self.assertTrue('<h2>Host private.localhost' in data)
+            self.assertTrue('Back to <a href="/site/1">' in data)
             self.assertTrue(
-                '<title>Host - MirrorManager</title>' in output.data)
+                '<title>Host - MirrorManager</title>' in data)
             self.assertTrue(
-                'action="/host/3/host_asn/1/delete">' in output.data)
+                'action="/host/3/host_asn/1/delete">' in data)
 
             # Delete Host ASN
 
-            data['csrf_token'] = csrf_token
+            post_data['csrf_token'] = csrf_token
 
             # Invalid site identifier
-            output = self.app.post('/host/5/host_asn/1/delete', data=data,
+            output = self.app.post('/host/5/host_asn/1/delete', data=post_data,
                                    follow_redirects=True)
             self.assertEqual(output.status_code, 404)
-            self.assertTrue('<p>Host not found</p>' in output.data)
+            data = output.get_data(as_text=True)
+            self.assertTrue('<p>Host not found</p>' in data)
 
             # Invalid Host ASN identifier
-            output = self.app.post('/host/3/host_asn/2/delete', data=data,
+            output = self.app.post('/host/3/host_asn/2/delete', data=post_data,
                                    follow_redirects=True)
             self.assertEqual(output.status_code, 404)
-            self.assertTrue('<p>Host Peer ASN not found</p>' in output.data)
+            data = output.get_data(as_text=True)
+            self.assertTrue('<p>Host Peer ASN not found</p>' in data)
 
             # Delete Host ASN
             output = self.app.post(
-                '/host/3/host_asn/1/delete', data=data,
+                '/host/3/host_asn/1/delete', data=post_data,
                 follow_redirects=True)
             self.assertEqual(output.status_code, 200)
+            data = output.get_data(as_text=True)
             self.assertTrue(
                 '<li class="message">Host Peer ASN deleted</li>'
-                in output.data)
-            self.assertTrue('<h2>Host private.localhost' in output.data)
-            self.assertTrue('Back to <a href="/site/1">' in output.data)
+                in data)
+            self.assertTrue('<h2>Host private.localhost' in data)
+            self.assertTrue('Back to <a href="/site/1">' in data)
             self.assertTrue(
-                '<title>Host - MirrorManager</title>' in output.data)
+                '<title>Host - MirrorManager</title>' in data)
             self.assertFalse(
-                'action="/host/3/host_asn/1/delete">' in output.data)
+                'action="/host/3/host_asn/1/delete">' in data)
 
     def test_host_country_new(self):
         """ Test the host_country_new endpoint. """
         output = self.app.get('/host/5/country/new')
         self.assertEqual(output.status_code, 302)
-        output = self.app.get('/host/5/country/new', follow_redirects=True)
 
+        output = self.app.get('/host/5/country/new', follow_redirects=True)
         self.assertEqual(output.status_code, 200)
+        data = output.get_data(as_text=True)
         if self.network_tests:
             self.assertTrue(
                 '<title>OpenID transaction in progress</title>'
-                in output.data)
+                in data)
 
         user = tests.AnotherFakeFasUser()
         with tests.user_set(mirrormanager2.app.APP, user):
             output = self.app.get('/host/50/country/new')
             self.assertEqual(output.status_code, 404)
-            self.assertTrue('<p>Host not found</p>' in output.data)
+            data = output.get_data(as_text=True)
+            self.assertTrue('<p>Host not found</p>' in data)
 
             output = self.app.get('/host/3/country/new')
             self.assertEqual(output.status_code, 200)
+            data = output.get_data(as_text=True)
             self.assertTrue(
-                '<h2>Add host country allowed</h2>' in output.data)
-            self.assertTrue('Back to <a href="/host/3">' in output.data)
+                '<h2>Add host country allowed</h2>' in data)
+            self.assertTrue('Back to <a href="/host/3">' in data)
             self.assertTrue(
                 '<title>New Host Country - MirrorManager</title>'
-                in output.data)
+                in data)
             self.assertFalse(
-                'action="/host/3/host_country/3/delete">' in output.data)
+                'action="/host/3/host_country/3/delete">' in data)
 
-            csrf_token = output.data.split(
+            csrf_token = data.split(
                 'name="csrf_token" type="hidden" value="')[1].split('">')[0]
 
-            data = {
+            post_data = {
                 'country': 'GB',
             }
 
             # Check CSRF protection
 
-            output = self.app.post('/host/3/country/new', data=data,
+            output = self.app.post('/host/3/country/new', data=post_data,
                                    follow_redirects=True)
             self.assertEqual(output.status_code, 200)
+            data = output.get_data(as_text=True)
             self.assertTrue(
-                '<h2>Add host country allowed</h2>' in output.data)
-            self.assertTrue('Back to <a href="/host/3">' in output.data)
+                '<h2>Add host country allowed</h2>' in data)
+            self.assertTrue('Back to <a href="/host/3">' in data)
             self.assertTrue(
                 '<title>New Host Country - MirrorManager</title>'
-                in output.data)
+                in data)
             self.assertFalse(
-                'action="/host/3/host_country/3/delete">' in output.data)
+                'action="/host/3/host_country/3/delete">' in data)
 
             # Invalid Country code
 
-            data['csrf_token'] = csrf_token
+            post_data['csrf_token'] = csrf_token
 
-            output = self.app.post('/host/3/country/new', data=data,
+            output = self.app.post('/host/3/country/new', data=post_data,
                                    follow_redirects=True)
             self.assertEqual(output.status_code, 200)
+            data = output.get_data(as_text=True)
             self.assertTrue(
                 '<li class="message">Invalid country code</li>'
-                in output.data)
+                in data)
             self.assertTrue(
-                '<h2>Add host country allowed</h2>' in output.data)
-            self.assertTrue('Back to <a href="/host/3">' in output.data)
+                '<h2>Add host country allowed</h2>' in data)
+            self.assertTrue('Back to <a href="/host/3">' in data)
             self.assertTrue(
                 '<title>New Host Country - MirrorManager</title>'
-                in output.data)
+                in data)
             self.assertFalse(
-                'action="/host/3/host_country/3/delete">' in output.data)
+                'action="/host/3/host_country/3/delete">' in data)
 
             # Create Country
 
-            data['country'] = 'FR'
+            post_data['country'] = 'FR'
 
-            output = self.app.post('/host/3/country/new', data=data,
+            output = self.app.post('/host/3/country/new', data=post_data,
                                    follow_redirects=True)
             self.assertEqual(output.status_code, 200)
+            data = output.get_data(as_text=True)
             self.assertTrue(
-                '<li class="message">Host Country added</li>' in output.data)
-            self.assertTrue('<h2>Host private.localhost' in output.data)
-            self.assertTrue('Back to <a href="/site/1">' in output.data)
+                '<li class="message">Host Country added</li>' in data)
+            self.assertTrue('<h2>Host private.localhost' in data)
+            self.assertTrue('Back to <a href="/site/1">' in data)
             self.assertTrue(
-                '<title>Host - MirrorManager</title>' in output.data)
+                '<title>Host - MirrorManager</title>' in data)
             self.assertTrue(
-                'action="/host/3/host_country/3/delete">' in output.data)
+                'action="/host/3/host_country/3/delete">' in data)
 
     def test_host_country_delete(self):
         """ Test the host_country_delete endpoint. """
         output = self.app.post('/host/1/host_country/1/delete')
         self.assertEqual(output.status_code, 302)
+
         output = self.app.post(
             '/host/1/host_country/2/delete', follow_redirects=True)
         self.assertEqual(output.status_code, 200)
+        data = output.get_data(as_text=True)
         if self.network_tests:
             self.assertTrue(
                 '<title>OpenID transaction in progress</title>'
-                in output.data)
+                in data)
 
         user = tests.AnotherFakeFasUser()
         with tests.user_set(mirrormanager2.app.APP, user):
@@ -1033,190 +1123,205 @@ class FlaskUiAppTest(tests.Modeltests):
             # Check before adding the host
             output = self.app.get('/host/1')
             self.assertEqual(output.status_code, 200)
-            self.assertTrue('<h2>Host mirror.localhost' in output.data)
-            self.assertTrue('Back to <a href="/site/1">' in output.data)
+            data = output.get_data(as_text=True)
+            self.assertTrue('<h2>Host mirror.localhost' in data)
+            self.assertTrue('Back to <a href="/site/1">' in data)
             self.assertTrue(
-                '<title>Host - MirrorManager</title>' in output.data)
+                '<title>Host - MirrorManager</title>' in data)
             self.assertTrue(
-                'action="/host/1/host_country/1/delete">' in output.data)
+                'action="/host/1/host_country/1/delete">' in data)
 
-            csrf_token = output.data.split(
+            csrf_token = data.split(
                 'name="csrf_token" type="hidden" value="')[1].split('">')[0]
 
-            data = {}
+            post_data = {}
 
             # Check CSRF protection
 
-            output = self.app.post('/host/1/host_country/1/delete', data=data,
+            output = self.app.post('/host/1/host_country/1/delete', data=post_data,
                                    follow_redirects=True)
             self.assertEqual(output.status_code, 200)
-            self.assertTrue('<h2>Host mirror.localhost' in output.data)
-            self.assertTrue('Back to <a href="/site/1">' in output.data)
+            data = output.get_data(as_text=True)
+            self.assertTrue('<h2>Host mirror.localhost' in data)
+            self.assertTrue('Back to <a href="/site/1">' in data)
             self.assertTrue(
-                '<title>Host - MirrorManager</title>' in output.data)
+                '<title>Host - MirrorManager</title>' in data)
             self.assertTrue(
-                'action="/host/1/host_country/1/delete">' in output.data)
+                'action="/host/1/host_country/1/delete">' in data)
 
             # Delete Host Country
 
-            data['csrf_token'] = csrf_token
+            post_data['csrf_token'] = csrf_token
 
             # Invalid site identifier
-            output = self.app.post('/host/5/host_country/1/delete', data=data,
+            output = self.app.post('/host/5/host_country/1/delete', data=post_data,
                                    follow_redirects=True)
             self.assertEqual(output.status_code, 404)
-            self.assertTrue('<p>Host not found</p>' in output.data)
+            data = output.get_data(as_text=True)
+            self.assertTrue('<p>Host not found</p>' in data)
 
             # Invalid Host Country identifier
-            output = self.app.post('/host/1/host_country/5/delete', data=data,
+            output = self.app.post('/host/1/host_country/5/delete', data=post_data,
                                    follow_redirects=True)
             self.assertEqual(output.status_code, 404)
-            self.assertTrue('<p>Host Country not found</p>' in output.data)
+            data = output.get_data(as_text=True)
+            self.assertTrue('<p>Host Country not found</p>' in data)
 
             # Delete Host Country
             output = self.app.post(
-                '/host/1/host_country/1/delete', data=data,
+                '/host/1/host_country/1/delete', data=post_data,
                 follow_redirects=True)
             self.assertEqual(output.status_code, 200)
+            data = output.get_data(as_text=True)
             self.assertTrue(
                 '<li class="message">Host Country deleted</li>'
-                in output.data)
-            self.assertTrue('<h2>Host mirror.localhost' in output.data)
-            self.assertTrue('Back to <a href="/site/1">' in output.data)
+                in data)
+            self.assertTrue('<h2>Host mirror.localhost' in data)
+            self.assertTrue('Back to <a href="/site/1">' in data)
             self.assertTrue(
-                '<title>Host - MirrorManager</title>' in output.data)
+                '<title>Host - MirrorManager</title>' in data)
             self.assertFalse(
-                'action="/host/1/host_country/1/delete">' in output.data)
+                'action="/host/1/host_country/1/delete">' in data)
 
     def test_host_category_new(self):
         """ Test the host_category_new endpoint. """
         output = self.app.get('/host/5/category/new')
         self.assertEqual(output.status_code, 302)
-        output = self.app.get('/host/5/category/new', follow_redirects=True)
 
+        output = self.app.get('/host/5/category/new', follow_redirects=True)
         self.assertEqual(output.status_code, 200)
+        data = output.get_data(as_text=True)
         if self.network_tests:
             self.assertTrue(
                 '<title>OpenID transaction in progress</title>'
-                in output.data)
+                in data)
 
         user = tests.FakeFasUser()
         with tests.user_set(mirrormanager2.app.APP, user):
             output = self.app.get('/host/50/category/new')
             self.assertEqual(output.status_code, 404)
-            self.assertTrue('<p>Host not found</p>' in output.data)
+            data = output.get_data(as_text=True)
+            self.assertTrue('<p>Host not found</p>' in data)
 
             output = self.app.get('/host/2/category/new')
             self.assertEqual(output.status_code, 200)
+            data = output.get_data(as_text=True)
             self.assertTrue(
-                '<h2>Add host category</h2>' in output.data)
-            self.assertTrue('Back to <a href="/host/2">' in output.data)
+                '<h2>Add host category</h2>' in data)
+            self.assertTrue('Back to <a href="/host/2">' in data)
             self.assertTrue(
                 '<title>New Host Category - MirrorManager</title>'
-                in output.data)
+                in data)
             self.assertFalse(
-                'action="/host/2/category/1/delete">' in output.data)
+                'action="/host/2/category/1/delete">' in data)
 
-            csrf_token = output.data.split(
+            csrf_token = data.split(
                 'name="csrf_token" type="hidden" value="')[1].split('">')[0]
 
-            data = {
+            post_data = {
                 'category_id': 'Fedora Linux',
             }
 
             # Invalid input
 
-            output = self.app.post('/host/2/category/new', data=data,
+            output = self.app.post('/host/2/category/new', data=post_data,
                                    follow_redirects=True)
             self.assertEqual(output.status_code, 200)
+            data = output.get_data(as_text=True)
             self.assertTrue(
-                '<h2>Add host category</h2>' in output.data)
-            self.assertTrue('Back to <a href="/host/2">' in output.data)
+                '<h2>Add host category</h2>' in data)
+            self.assertTrue('Back to <a href="/host/2">' in data)
             self.assertTrue(
                 '<title>New Host Category - MirrorManager</title>'
-                in output.data)
+                in data)
             self.assertFalse(
-                'action="/host/2/category/1/delete">' in output.data)
+                'action="/host/2/category/1/delete">' in data)
             self.assertTrue(
                 'Not a valid choice<br />Field must contain a number'
-                in output.data)
+                in data)
 
             # Check CSRF protection
 
-            output = self.app.post('/host/2/category/new', data=data,
+            output = self.app.post('/host/2/category/new', data=post_data,
                                    follow_redirects=True)
             self.assertEqual(output.status_code, 200)
+            data = output.get_data(as_text=True)
             self.assertTrue(
-                '<h2>Add host category</h2>' in output.data)
-            self.assertTrue('Back to <a href="/host/2">' in output.data)
+                '<h2>Add host category</h2>' in data)
+            self.assertTrue('Back to <a href="/host/2">' in data)
             self.assertTrue(
                 '<title>New Host Category - MirrorManager</title>'
-                in output.data)
+                in data)
             self.assertFalse(
-                'action="/host/2/category/1/delete">' in output.data)
+                'action="/host/2/category/1/delete">' in data)
 
             # Delete before adding
 
-            data['csrf_token'] = csrf_token
+            post_data['csrf_token'] = csrf_token
 
             output = self.app.post(
-                '/host/2/category/4/delete', data=data,
+                '/host/2/category/4/delete', data=post_data,
                 follow_redirects=True)
             self.assertEqual(output.status_code, 200)
 
             # Add Category
 
-            data['csrf_token'] = csrf_token
-            data['category_id'] = '2'
+            post_data['csrf_token'] = csrf_token
+            post_data['category_id'] = '2'
 
-            output = self.app.post('/host/2/category/new', data=data,
+            output = self.app.post('/host/2/category/new', data=post_data,
                                    follow_redirects=True)
             self.assertEqual(output.status_code, 200)
+            data = output.get_data(as_text=True)
             self.assertTrue(
-                '<li class="message">Host Category added</li>' in output.data)
-            self.assertTrue('<h2>Host category</h2>' in output.data)
-            self.assertTrue('Back to <a href="/site/2">' in output.data)
+                '<li class="message">Host Category added</li>' in data)
+            self.assertTrue('<h2>Host category</h2>' in data)
+            self.assertTrue('Back to <a href="/site/2">' in data)
             self.assertTrue(
-                '<title>Host Category - MirrorManager</title>' in output.data)
+                '<title>Host Category - MirrorManager</title>' in data)
 
             # Try adding the same Category -- fails
 
-            output = self.app.post('/host/2/category/new', data=data,
+            output = self.app.post('/host/2/category/new', data=post_data,
                                    follow_redirects=True)
             self.assertEqual(output.status_code, 200)
+            data = output.get_data(as_text=True)
             self.assertTrue(
                 '<li class="message">Could not add Category to the host</li>'
-                in output.data)
+                in data)
             self.assertTrue(
-                '<h2>Add host category</h2>' in output.data)
-            self.assertTrue('Back to <a href="/host/2">' in output.data)
+                '<h2>Add host category</h2>' in data)
+            self.assertTrue('Back to <a href="/host/2">' in data)
             self.assertTrue(
                 '<title>New Host Category - MirrorManager</title>'
-                in output.data)
+                in data)
             self.assertFalse(
-                'action="/host/2/category/1/delete">' in output.data)
+                'action="/host/2/category/1/delete">' in data)
 
             # Check host after adding the category
             output = self.app.get('/host/2')
             self.assertEqual(output.status_code, 200)
-            self.assertTrue('<h2>Host mirror2.localhost' in output.data)
-            self.assertTrue('Back to <a href="/site/2">' in output.data)
+            data = output.get_data(as_text=True)
+            self.assertTrue('<h2>Host mirror2.localhost' in data)
+            self.assertTrue('Back to <a href="/site/2">' in data)
             self.assertTrue(
-                '<title>Host - MirrorManager</title>' in output.data)
+                '<title>Host - MirrorManager</title>' in data)
             self.assertTrue(
-                'action="/host/2/category/4/delete">' in output.data)
+                'action="/host/2/category/4/delete">' in data)
 
     def test_host_category_delete(self):
         """ Test the host_category_delete endpoint. """
         output = self.app.post('/host/1/category/1/delete')
         self.assertEqual(output.status_code, 302)
+
         output = self.app.post(
             '/host/1/category/1/delete', follow_redirects=True)
         self.assertEqual(output.status_code, 200)
+        data = output.get_data(as_text=True)
         if self.network_tests:
             self.assertTrue(
                 '<title>OpenID transaction in progress</title>'
-                in output.data)
+                in data)
 
         user = tests.FakeFasUser()
         with tests.user_set(mirrormanager2.app.APP, user):
@@ -1224,179 +1329,195 @@ class FlaskUiAppTest(tests.Modeltests):
             # Check before deleting the category
             output = self.app.get('/host/2')
             self.assertEqual(output.status_code, 200)
-            self.assertTrue('<h2>Host mirror2.localhost' in output.data)
-            self.assertTrue('Back to <a href="/site/2">' in output.data)
+            data = output.get_data(as_text=True)
+            self.assertTrue('<h2>Host mirror2.localhost' in data)
+            self.assertTrue('Back to <a href="/site/2">' in data)
             self.assertTrue(
-                '<title>Host - MirrorManager</title>' in output.data)
+                '<title>Host - MirrorManager</title>' in data)
             self.assertTrue(
-                'action="/host/2/category/3/delete">' in output.data)
+                'action="/host/2/category/3/delete">' in data)
 
-            csrf_token = output.data.split(
+            csrf_token = data.split(
                 'name="csrf_token" type="hidden" value="')[1].split('">')[0]
 
-            data = {}
+            post_data = {}
 
             # Check CSRF protection
 
-            output = self.app.post('/host/2/category/1/delete', data=data,
+            output = self.app.post('/host/2/category/1/delete', data=post_data,
                                    follow_redirects=True)
             self.assertEqual(output.status_code, 200)
-            self.assertTrue('<h2>Host mirror2.localhost' in output.data)
-            self.assertTrue('Back to <a href="/site/2">' in output.data)
+            data = output.get_data(as_text=True)
+            self.assertTrue('<h2>Host mirror2.localhost' in data)
+            self.assertTrue('Back to <a href="/site/2">' in data)
             self.assertTrue(
-                '<title>Host - MirrorManager</title>' in output.data)
+                '<title>Host - MirrorManager</title>' in data)
             self.assertTrue(
-                'action="/host/2/category/3/delete">' in output.data)
+                'action="/host/2/category/3/delete">' in data)
 
             # Delete Host Category
 
-            data['csrf_token'] = csrf_token
+            post_data['csrf_token'] = csrf_token
 
             # Invalid site identifier
-            output = self.app.post('/host/5/category/1/delete', data=data,
+            output = self.app.post('/host/5/category/1/delete', data=post_data,
                                    follow_redirects=True)
             self.assertEqual(output.status_code, 404)
-            self.assertTrue('<p>Host not found</p>' in output.data)
+            data = output.get_data(as_text=True)
+            self.assertTrue('<p>Host not found</p>' in data)
 
             # Invalid Host Category identifier
-            output = self.app.post('/host/2/category/50/delete', data=data,
+            output = self.app.post('/host/2/category/50/delete', data=post_data,
                                    follow_redirects=True)
             self.assertEqual(output.status_code, 404)
-            self.assertTrue('<p>Host/Category not found</p>' in output.data)
+            data = output.get_data(as_text=True)
+            self.assertTrue('<p>Host/Category not found</p>' in data)
 
             # Invalid Host/Category association
-            output = self.app.post('/host/2/category/1/delete', data=data,
+            output = self.app.post('/host/2/category/1/delete', data=post_data,
                                    follow_redirects=True)
             self.assertEqual(output.status_code, 404)
+            data = output.get_data(as_text=True)
             self.assertTrue(
                 '<p>Category not associated with this host</p>'
-                in output.data)
+                in data)
 
             # Delete Host Category
             output = self.app.post(
-                '/host/2/category/3/delete', data=data,
+                '/host/2/category/3/delete', data=post_data,
                 follow_redirects=True)
             self.assertEqual(output.status_code, 200)
+            data = output.get_data(as_text=True)
             self.assertTrue(
                 '<li class="message">Host Category deleted</li>'
-                in output.data)
-            self.assertTrue('<h2>Host mirror2.localhost' in output.data)
-            self.assertTrue('Back to <a href="/site/2">' in output.data)
+                in data)
+            self.assertTrue('<h2>Host mirror2.localhost' in data)
+            self.assertTrue('Back to <a href="/site/2">' in data)
             self.assertTrue(
-                '<title>Host - MirrorManager</title>' in output.data)
+                '<title>Host - MirrorManager</title>' in data)
             self.assertFalse(
-                'action="/host/2/category/1/delete">' in output.data)
+                'action="/host/2/category/1/delete">' in data)
 
     def test_host_category_url_new(self):
         """ Test the host_category_url_new endpoint. """
         output = self.app.get('/host/1/category/1/url/new')
         self.assertEqual(output.status_code, 302)
+
         output = self.app.get(
             '/host/1/category/1/url/new', follow_redirects=True)
-
         self.assertEqual(output.status_code, 200)
+        data = output.get_data(as_text=True)
         if self.network_tests:
             self.assertTrue(
                 '<title>OpenID transaction in progress</title>'
-                in output.data)
+                in data)
 
         user = tests.FakeFasUser()
         with tests.user_set(mirrormanager2.app.APP, user):
             output = self.app.get('/host/50/category/1/url/new')
             self.assertEqual(output.status_code, 404)
-            self.assertTrue('<p>Host not found</p>' in output.data)
+            data = output.get_data(as_text=True)
+            self.assertTrue('<p>Host not found</p>' in data)
 
             output = self.app.get('/host/2/category/50/url/new')
             self.assertEqual(output.status_code, 404)
-            self.assertTrue('<p>Host/Category not found</p>' in output.data)
+            data = output.get_data(as_text=True)
+            self.assertTrue('<p>Host/Category not found</p>' in data)
 
             output = self.app.get('/host/2/category/1/url/new')
             self.assertEqual(output.status_code, 404)
+            data = output.get_data(as_text=True)
             self.assertTrue(
                 '<p>Category not associated with this host</p>'
-                in output.data)
+                in data)
 
             output = self.app.get('/host/2/category/3/url/new')
             self.assertEqual(output.status_code, 200)
+            data = output.get_data(as_text=True)
             self.assertTrue(
-                '<h2>Add host category URL</h2>' in output.data)
+                '<h2>Add host category URL</h2>' in data)
             self.assertTrue(
-                'test-mirror2</a> / <a href="/host/2">' in output.data)
+                'test-mirror2</a> / <a href="/host/2">' in data)
             self.assertTrue(
                 '<title>New Host Category URL - MirrorManager</title>'
-                in output.data)
+                in data)
             self.assertFalse(
-                'action="/host/2/category/3/url/5/delete">' in output.data)
+                'action="/host/2/category/3/url/5/delete">' in data)
 
-            csrf_token = output.data.split(
+            csrf_token = data.split(
                 'name="csrf_token" type="hidden" value="')[1].split('">')[0]
 
-            data = {
+            post_data = {
                 'url': 'http://pingoured.fr/pub/Fedora/',
             }
 
             # Check CSRF protection
 
-            output = self.app.post('/host/2/category/3/url/new', data=data,
+            output = self.app.post('/host/2/category/3/url/new', data=post_data,
                                    follow_redirects=True)
             self.assertEqual(output.status_code, 200)
+            data = output.get_data(as_text=True)
             self.assertTrue(
-                '<h2>Add host category URL</h2>' in output.data)
+                '<h2>Add host category URL</h2>' in data)
             self.assertTrue(
-                'test-mirror2</a> / <a href="/host/2">' in output.data)
+                'test-mirror2</a> / <a href="/host/2">' in data)
             self.assertTrue(
                 '<title>New Host Category URL - MirrorManager</title>'
-                in output.data)
+                in data)
             self.assertFalse(
-                'action="/host/2/category/3/url/5/delete">' in output.data)
+                'action="/host/2/category/3/url/5/delete">' in data)
 
             # Add Host Category URL
 
-            data['csrf_token'] = csrf_token
+            post_data['csrf_token'] = csrf_token
 
-            output = self.app.post('/host/2/category/3/url/new', data=data,
+            output = self.app.post('/host/2/category/3/url/new', data=post_data,
                                    follow_redirects=True)
             self.assertEqual(output.status_code, 200)
+            data = output.get_data(as_text=True)
             self.assertTrue(
                 '<li class="message">Host Category URL added</li>'
-                in output.data)
-            self.assertTrue('<h2>Host category</h2>' in output.data)
+                in data)
+            self.assertTrue('<h2>Host category</h2>' in data)
             self.assertTrue(
-                'test-mirror2</a> / <a href="/host/2">' in output.data)
+                'test-mirror2</a> / <a href="/host/2">' in data)
             self.assertTrue(
-                '<title>Host Category - MirrorManager</title>' in output.data)
+                '<title>Host Category - MirrorManager</title>' in data)
             self.assertTrue(
-                'action="/host/2/category/3/url/9/delete">' in output.data)
+                'action="/host/2/category/3/url/9/delete">' in data)
 
             # Try adding the same Host Category URL -- fails
 
-            data['csrf_token'] = csrf_token
+            post_data['csrf_token'] = csrf_token
 
-            output = self.app.post('/host/2/category/3/url/new', data=data,
+            output = self.app.post('/host/2/category/3/url/new', data=post_data,
                                    follow_redirects=True)
             self.assertEqual(output.status_code, 200)
+            data = output.get_data(as_text=True)
             self.assertTrue(
                 'class="message">Could not add Category URL to the host</li>'
-                in output.data)
-            self.assertTrue('<h2>Host category</h2>' in output.data)
+                in data)
+            self.assertTrue('<h2>Host category</h2>' in data)
             self.assertTrue(
-                'test-mirror2</a> / <a href="/host/2">' in output.data)
+                'test-mirror2</a> / <a href="/host/2">' in data)
             self.assertTrue(
-                '<title>Host Category - MirrorManager</title>' in output.data)
+                '<title>Host Category - MirrorManager</title>' in data)
             self.assertTrue(
-                'action="/host/2/category/3/url/9/delete">' in output.data)
+                'action="/host/2/category/3/url/9/delete">' in data)
 
     def test_host_category_url_delete(self):
         """ Test the host_category_url_delete endpoint. """
         output = self.app.post('/host/1/category/1/url/3/delete')
         self.assertEqual(output.status_code, 302)
+
         output = self.app.post(
             '/host/1/category/1/url/3/delete', follow_redirects=True)
         self.assertEqual(output.status_code, 200)
+        data = output.get_data(as_text=True)
         if self.network_tests:
             self.assertTrue(
                 '<title>OpenID transaction in progress</title>'
-                in output.data)
+                in data)
 
         user = tests.FakeFasUser()
         with tests.user_set(mirrormanager2.app.APP, user):
@@ -1404,145 +1525,163 @@ class FlaskUiAppTest(tests.Modeltests):
             # Check before deleting the category URL
             output = self.app.get('/host/2/category/3')
             self.assertEqual(output.status_code, 200)
-            self.assertTrue('<h2>Host category</h2>' in output.data)
-            self.assertTrue('Back to <a href="/site/2">' in output.data)
+            data = output.get_data(as_text=True)
+            self.assertTrue('<h2>Host category</h2>' in data)
+            self.assertTrue('Back to <a href="/site/2">' in data)
             self.assertTrue(
-                '<title>Host Category - MirrorManager</title>' in output.data)
+                '<title>Host Category - MirrorManager</title>' in data)
             self.assertTrue(
-                'action="/host/2/category/3/url/5/delete">' in output.data)
+                'action="/host/2/category/3/url/5/delete">' in data)
 
-            csrf_token = output.data.split(
+            csrf_token = data.split(
                 'name="csrf_token" type="hidden" value="')[1].split('">')[0]
 
-            data = {}
+            post_data = {}
 
             # Check CSRF protection
 
             output = self.app.post(
-                '/host/2/category/3/url/5/delete', data=data,
+                '/host/2/category/3/url/5/delete', data=post_data,
                 follow_redirects=True)
             self.assertEqual(output.status_code, 200)
-            self.assertTrue('<h2>Host category</h2>' in output.data)
-            self.assertTrue('Back to <a href="/site/2">' in output.data)
+            data = output.get_data(as_text=True)
+            self.assertTrue('<h2>Host category</h2>' in data)
+            self.assertTrue('Back to <a href="/site/2">' in data)
             self.assertTrue(
-                '<title>Host Category - MirrorManager</title>' in output.data)
+                '<title>Host Category - MirrorManager</title>' in data)
             self.assertTrue(
-                'action="/host/2/category/3/url/5/delete">' in output.data)
+                'action="/host/2/category/3/url/5/delete">' in data)
 
             # Delete Host Category URL
 
-            data['csrf_token'] = csrf_token
+            post_data['csrf_token'] = csrf_token
 
             # Invalid site identifier
             output = self.app.post(
-                '/host/5/category/5/url/5/delete', data=data,
+                '/host/5/category/5/url/5/delete', data=post_data,
                 follow_redirects=True)
             self.assertEqual(output.status_code, 404)
-            self.assertTrue('<p>Host not found</p>' in output.data)
+            data = output.get_data(as_text=True)
+            self.assertTrue('<p>Host not found</p>' in data)
 
             # Invalid Host Category identifier
             output = self.app.post(
-                '/host/2/category/50/url/5/delete', data=data,
+                '/host/2/category/50/url/5/delete', data=post_data,
                 follow_redirects=True)
             self.assertEqual(output.status_code, 404)
-            self.assertTrue('<p>Host/Category not found</p>' in output.data)
+            data = output.get_data(as_text=True)
+            self.assertTrue('<p>Host/Category not found</p>' in data)
 
             # Invalid Host/Category association
             output = self.app.post(
-                '/host/2/category/3/url/4/delete', data=data,
+                '/host/2/category/3/url/4/delete', data=post_data,
                 follow_redirects=True)
             self.assertEqual(output.status_code, 404)
+            data = output.get_data(as_text=True)
             self.assertTrue(
                 '<p>Category URL not associated with this host</p>'
-                in output.data)
+                in data)
 
             # Invalid Category/URL
             output = self.app.post(
-                '/host/2/category/3/url/50/delete', data=data,
+                '/host/2/category/3/url/50/delete', data=post_data,
                 follow_redirects=True)
             self.assertEqual(output.status_code, 404)
+            data = output.get_data(as_text=True)
             self.assertTrue(
                 '<p>Host category URL not found</p>'
-                in output.data)
+                in data)
 
             # Invalid Category/URL association
             output = self.app.post(
-                '/host/2/category/2/url/4/delete', data=data,
+                '/host/2/category/2/url/4/delete', data=post_data,
                 follow_redirects=True)
             self.assertEqual(output.status_code, 404)
+            data = output.get_data(as_text=True)
             self.assertTrue(
                 '<p>Category not associated with this host</p>'
-                in output.data)
+                in data)
 
             # Delete Host Category URL
             output = self.app.post(
-                '/host/2/category/3/url/5/delete', data=data,
+                '/host/2/category/3/url/5/delete', data=post_data,
                 follow_redirects=True)
             self.assertEqual(output.status_code, 200)
+            data = output.get_data(as_text=True)
             self.assertTrue(
                 '<li class="message">Host category URL deleted</li>'
-                in output.data)
-            self.assertTrue('<h2>Host category</h2>' in output.data)
-            self.assertTrue('Back to <a href="/site/2">' in output.data)
+                in data)
+            self.assertTrue('<h2>Host category</h2>' in data)
+            self.assertTrue('Back to <a href="/site/2">' in data)
             self.assertTrue(
-                '<title>Host Category - MirrorManager</title>' in output.data)
+                '<title>Host Category - MirrorManager</title>' in data)
             self.assertFalse(
-                'action="/host/2/category/3/url/5/delete">' in output.data)
+                'action="/host/2/category/3/url/5/delete">' in data)
 
     def test_host_category(self):
         """ Test the host_category endpoint. """
 
         output = self.app.post('/host/2/category/5')
         self.assertEqual(output.status_code, 302)
+
         output = self.app.post('/host/2/category/5', follow_redirects=True)
         self.assertEqual(output.status_code, 200)
+        data = output.get_data(as_text=True)
         if self.network_tests:
             self.assertTrue(
                 '<title>OpenID transaction in progress</title>'
-                in output.data)
+                in data)
 
         user = tests.FakeFasUser()
         with tests.user_set(mirrormanager2.app.APP, user):
             output = self.app.get('/host/50/category/5')
             self.assertEqual(output.status_code, 404)
-            self.assertTrue('<p>Host not found</p>' in output.data)
+            data = output.get_data(as_text=True)
+            self.assertTrue('<p>Host not found</p>' in data)
 
             output = self.app.get('/host/2/category/50')
             self.assertEqual(output.status_code, 404)
-            self.assertTrue('<p>Host/Category not found</p>' in output.data)
+            data = output.get_data(as_text=True)
+            self.assertTrue('<p>Host/Category not found</p>' in data)
 
             output = self.app.get('/host/2/category/2')
             self.assertEqual(output.status_code, 404)
+            data = output.get_data(as_text=True)
             self.assertTrue(
                 '<p>Category not associated with this host</p>'
-                in output.data)
+                in data)
 
             output = self.app.get('/host/2/category/3')
             self.assertEqual(output.status_code, 200)
+            data = output.get_data(as_text=True)
             self.assertTrue(
                 '<h3>Up-to-Date Directories this host carries</h3>'
-                in output.data)
+                in data)
 
     def test_auth_logout(self):
         """ Test the auth_logout endpoint. """
         output = self.app.get('/logout')
         self.assertEqual(output.status_code, 302)
+
         output = self.app.get('/logout', follow_redirects=True)
         self.assertEqual(output.status_code, 200)
+        data = output.get_data(as_text=True)
         self.assertTrue(
-            '<h2>Fedora Public Active Mirrors</h2>' in output.data)
+            '<h2>Fedora Public Active Mirrors</h2>' in data)
 
         user = tests.FakeFasUser()
         with tests.user_set(mirrormanager2.app.APP, user):
             output = self.app.get('/logout')
             self.assertEqual(output.status_code, 302)
+
             output = self.app.get('/logout', follow_redirects=True)
             self.assertEqual(output.status_code, 200)
+            data = output.get_data(as_text=True)
             self.assertTrue(
                 '<li class="message">You are no longer logged-in</li>'
-                in output.data)
+                in data)
             self.assertTrue(
-                '<h2>Fedora Public Active Mirrors</h2>' in output.data)
+                '<h2>Fedora Public Active Mirrors</h2>' in data)
 
 if __name__ == '__main__':
     SUITE = unittest.TestLoader().loadTestsFromTestCase(FlaskUiAppTest)

--- a/tests/test_umdl.py
+++ b/tests/test_umdl.py
@@ -90,7 +90,8 @@ class UMDLTest(tests.Modeltests):
 
         process = subprocess.Popen(
             args=self.umdl_command.split(),
-            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+            universal_newlines=True)
         stdout, stderr = process.communicate()
 
         self.assertEqual(stdout, '')
@@ -127,7 +128,8 @@ Fedora Other:Ending umdl
 
         process = subprocess.Popen(
             args=self.umdl_command.split(),
-            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+            universal_newlines=True)
         stdout, stderr = process.communicate()
 
         self.assertEqual(stdout, '')

--- a/tests/test_umdl.py
+++ b/tests/test_umdl.py
@@ -4,6 +4,8 @@
 mirrormanager2 tests for the `Update Master Directory List` (UMDL) cron.
 '''
 
+from __future__ import print_function
+
 __requires__ = ['SQLAlchemy >= 0.7']
 import pkg_resources
 
@@ -100,7 +102,7 @@ class UMDLTest(tests.Modeltests):
             log.split(':', 3)[-1]
             for log in logs
         ])
-        print logs
+        print(logs)
         exp = """N/A:Starting umdl
 Fedora EPEL:umdl_master_directories Category Fedora EPEL does not exist in the database, skipping
 Fedora Linux:umdl_master_directories Category Fedora Linux does not exist in the database, skipping

--- a/utility/mm2_crawler
+++ b/utility/mm2_crawler
@@ -427,32 +427,32 @@ class hostState:
     def get_connection(self, url):
         scheme, netloc, path, query, fragment = urlparse.urlsplit(url)
         if scheme == 'ftp':
-            if self.ftpconn.has_key(netloc):
+            if netloc in self.ftpconn:
                 return self.ftpconn[netloc]
         elif scheme == 'http':
-            if self.httpconn.has_key(netloc):
+            if netloc in self.httpconn:
                 return self.httpconn[netloc]
         elif scheme == 'https':
-            if self.httpsconn.has_key(netloc):
+            if netloc in self.httpsconn:
                 return self.httspconn[netloc]
         return None
 
     def open_http(self, url):
         scheme, netloc, path, query, fragment = urlparse.urlsplit(url)
         if scheme == 'http':
-            if not self.httpconn.has_key(netloc):
+            if netloc not in self.httpconn:
                 self.httpconn[netloc] = myHTTPConnection(netloc, timeout=self.timeout)
                 self.httpconn[netloc].set_debuglevel(self.http_debuglevel)
             return self.httpconn[netloc]
 
         elif scheme == 'https':
-            if not self.httpsconn.has_key(netloc):
+            if netloc not in self.httpsconn:
                 self.httpsconn[netloc] = myHTTPSConnection(netloc, timeout=self.timeout)
                 self.httpsconn[netloc].set_debuglevel(self.http_debuglevel)
             return self.httpsconn[netloc]
 
     def _open_ftp(self, netloc):
-        if not self.ftpconn.has_key(netloc):
+        if netloc not in self.ftpconn:
             self.ftpconn[netloc] = FTP(netloc, timeout=self.timeout)
             self.ftpconn[netloc].set_debuglevel(self.ftp_debuglevel)
             self.ftpconn[netloc].login()
@@ -473,18 +473,18 @@ class hostState:
     def close_http(self, url):
         scheme, netloc, path, query, fragment = urlparse.urlsplit(url)
         if scheme == 'http':
-            if self.httpconn.has_key(netloc):
+            if netloc in self.httpconn:
                 self.httpconn[netloc].close()
                 del self.httpconn[netloc]
 
         elif scheme == 'https':
-            if self.httpsconn.has_key(netloc):
+            if netlock in self.httpsconn:
                 self.httpsconn[netloc].close()
                 del self.httpsconn[netloc]
 
     def close_ftp(self, url):
         scheme, netloc, path, query, fragment = urlparse.urlsplit(url)
-        if self.ftpconn.has_key(netloc):
+        if netlock in self.ftpconn:
             try:
                 self.ftpconn[netloc].quit()
             except:

--- a/utility/mm2_crawler
+++ b/utility/mm2_crawler
@@ -516,7 +516,7 @@ def get_ftp_dir(hoststate, url, readable, i=0):
 
     try:
         hoststate.ftp_dir(url)
-    except ftplib.error_perm, e:
+    except ftplib.error_perm as e:
         # Returned by Princeton University when directory does not exist
         if str(e).startswith('550'):
             return []
@@ -537,7 +537,7 @@ def get_ftp_dir(hoststate, url, readable, i=0):
         else:
             logger.error("unknown permanent error %s on %s" % (e, url))
             raise
-    except ftplib.error_temp, e:
+    except ftplib.error_temp as e:
         # Returned by Boston University when directory does not exist
         if str(e).startswith('450'):
             return []

--- a/utility/mm2_create_install_repo
+++ b/utility/mm2_create_install_repo
@@ -61,12 +61,12 @@ def doit(session, version_name, category_name, parent):
     category = mirrormanager2.lib.get_category_by_name(
         session, category_name)
     if not category:
-        print 'No such category found: %s' % category_name
+        print('No such category found: %s' % category_name)
         return 1
     ver = mirrormanager2.lib.get_version_by_name_version(
           session, category.product.name, version_name)
     if not ver:
-        print 'No such version found: %s' % version_name
+        print('No such version found: %s' % version_name)
         return 1
 
     for r in REPOS:

--- a/utility/mm2_generate-worldmap
+++ b/utility/mm2_generate-worldmap
@@ -9,6 +9,7 @@
 # while the rest of MirrorManager is licensed MIT/X11
 
 
+from __future__ import print_function
 import sys
 import os
 import string
@@ -61,14 +62,14 @@ def lookup_host_locations(config):
             name = "N/A"
         if gir is not None:
             if gir['country_code'] in embargoed_countries:
-                print "skipping " + hn
+                print("skipping " + hn)
                 continue
             t = (
                 hn,
                 gir['country_code'],
                 gir['latitude'],
                 gir['longitude'])
-            print "%s %s %s %s" % t
+            print("%s %s %s %s" % t)
             results.append([t, name])
             tracking.append(hn)
 

--- a/utility/mm2_last-sync
+++ b/utility/mm2_last-sync
@@ -21,6 +21,7 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import requests
 import time
 import sys
@@ -43,22 +44,22 @@ delta = 86400
 quiet = False
 
 def usage():
-	print
-	print "last-sync queries the Fedora Message Bus if new data is available on the public servers"
-	print
-	print "Usage: last-sync [options]"
-	print
-	print "Options:"
-	print "  -a, --all                 query all possible releases (default)"
-	print "                            (fedora, epel, branched, rawhide)"
-	print "  -f, --fedora              only query if fedora has been updated during <delta>"
-	print "  -e, --epel                only query if epel has been updated"
-	print "  -b, --branched            only query if the branched off release"
-	print "                            has been updated"
-	print "  -r, --rawhide             only query if rawhide has been updated"
-	print "  -q, --quiet               do not print out any informations"
-	print "  -d DELTA, --delta=DELTA   specify the time interval which should be used"
-	print "                            for the query (default: 86400)"
+	print()
+	print("last-sync queries the Fedora Message Bus if new data is available on the public servers")
+	print()
+	print("Usage: last-sync [options]")
+	print()
+	print("Options:")
+	print("  -a, --all                 query all possible releases (default)")
+	print("                            (fedora, epel, branched, rawhide)")
+	print("  -f, --fedora              only query if fedora has been updated during <delta>")
+	print("  -e, --epel                only query if epel has been updated")
+	print("  -b, --branched            only query if the branched off release")
+	print("                            has been updated")
+	print("  -r, --rawhide             only query if rawhide has been updated")
+	print("  -q, --quiet               do not print out any informations")
+	print("  -d DELTA, --delta=DELTA   specify the time interval which should be used")
+	print("                            for the query (default: 86400)")
 
 
 # -a -f -e -b -r -q -d
@@ -69,7 +70,7 @@ def parse_args():
 	try:
 		opts, args = getopt.getopt(sys.argv[1:], "afhebrqd:", ["all", "fedora", "epel", "rawhide", "branched", "quiet", "delta="])
 	except getopt.GetoptError as err:
-		print str(err)
+		print(str(err))
 		usage()
 		sys.exit(2)
 
@@ -126,7 +127,7 @@ for i in range(0, data['count']):
 
 if quiet == False:
 	for repo, timestamp in sorted(repos, key=getKey):
-		print "%s: %s" % (repo, time.strftime("%a, %d %b %Y %H:%M:%S +0000", time.gmtime(timestamp)))
+		print("%s: %s" % (repo, time.strftime("%a, %d %b %Y %H:%M:%S +0000", time.gmtime(timestamp))))
 
 if data['count'] > 0:
 	sys.exit(0)

--- a/utility/mm2_move-devel-to-release
+++ b/utility/mm2_move-devel-to-release
@@ -12,6 +12,7 @@ tree (which is hardlinked to the release tree and thus will have the same
 content)
 """
 
+from __future__ import print_function
 import sys
 import re
 import os
@@ -61,15 +62,15 @@ def move_devel_repo(session, category, version):
 
     c = mirrormanager2.lib.get_category_by_name(session, category)
     if c is None:
-        print "Category '%s' not found, exiting" % category
+        print("Category '%s' not found, exiting" % category)
         print_categories(session)
         sys.exit(1)
 
     v = mirrormanager2.lib.get_version_by_name_version(
         session, c.product.name, version)
     if not v:
-        print 'Version %s not found for product %s' % (
-            version, c.product.name)
+        print('Version %s not found for product %s' % (
+            version, c.product.name))
         sys.exit(1)
 
     oldpattern = os.path.join('development', version)
@@ -101,12 +102,12 @@ def move_devel_repo(session, category, version):
                 # thus lead to a duplicate key value violation.
                 continue
             fixup_repos(session, v, r, new_d)
-            print "%s => %s" % (d.name, t)
+            print("%s => %s" % (d.name, t))
 
 def print_categories(session):
-    print "Available categories:"
+    print("Available categories:")
     for c in mirrormanager2.lib.get_categories(session):
-        print "\t%s" % c.name
+        print("\t%s" % c.name)
 
 
 def main():

--- a/utility/mm2_move-to-archive
+++ b/utility/mm2_move-to-archive
@@ -6,6 +6,7 @@ This script changes the directory path for a release once it goes EOL.
 In principle it should be run about a week after the said release went EOL.
 """
 
+from __future__ import print_function
 import sys
 import re
 import os
@@ -35,7 +36,7 @@ def doit(session, original_cat, archive_cat, directory_re):
         if dirRe.search(d.name):
             for r in d.repositories:
                 t = os.path.join(archivetopdir, d.name[len(originaltopdir)+1:])
-                print "trying to find %s" % t
+                print("trying to find %s" % t)
                 new_d = mirrormanager2.lib.get_directory_by_name(session, t)
                 if new_d is None:
                     raise Exception(
@@ -45,7 +46,7 @@ def doit(session, original_cat, archive_cat, directory_re):
                 r.category = a
                 session.add(r)
                 session.commit()
-                print "%s => %s" % (d.name, t)
+                print("%s => %s" % (d.name, t))
 
 
 def main():
@@ -88,7 +89,7 @@ def main():
             options.directoryRe)
         return 0
     except Exception, err:
-        print err
+        print(err)
         return 1
 
 

--- a/utility/mm2_move-to-archive
+++ b/utility/mm2_move-to-archive
@@ -88,7 +88,7 @@ def main():
             options.archiveCategory,
             options.directoryRe)
         return 0
-    except Exception, err:
+    except Exception as err:
         print(err)
         return 1
 

--- a/utility/mm2_propagation
+++ b/utility/mm2_propagation
@@ -21,6 +21,7 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import argparse
 import glob
 import matplotlib
@@ -127,12 +128,12 @@ args.prefix = os.path.join(args.outdir, args.prefix)
 total = len(glob.glob(args.logfiles))
 
 if not total:
-    print "No input files found at: " + args.logfiles
+    print("No input files found at: " + args.logfiles)
     sys.exit(0)
 
 remaining = total
 if args.debug:
-    print "%d data points available" % total
+    print("%d data points available" % total)
 
 proppath = None
 
@@ -222,52 +223,52 @@ for filename in sorted(glob.glob(args.logfiles)):
     labels.append(scandate)
 
 if args.debug:
-    print "%d data points used" % len(repomd_same)
+    print("%d data points used" % len(repomd_same))
 
 fd = open('%s-repomd-report.txt' % args.prefix, 'w')
 
 if args.debug:
-    print "Hosts broken"
+    print("Hosts broken")
 fd.write("Hosts broken\n")
 for url, count in sorted(
         hosts_broken.items(),
         key=lambda x: (int(x[1])),
         reverse=True):
     if args.debug:
-        print "%s: %d" % (url, count)
+        print("%s: %d" % (url, count))
     fd.write("%s: %d\n" % (url, count))
 
 if args.debug:
-    print "Hosts older"
+    print("Hosts older")
 fd.write("Hosts older\n")
 for url, count in sorted(
         hosts_older.items(),
         key=lambda x: (int(x[1])),
         reverse=True):
     if args.debug:
-        print "%s: %d" % (url, count)
+        print("%s: %d" % (url, count))
     fd.write("%s: %d\n" % (url, count))
 
 if args.debug:
-    print "Hosts older - 1"
+    print("Hosts older - 1")
 fd.write("Hosts older - 1\n")
 for url, count in sorted(
         hosts_older_1.items(),
         key=lambda x: (int(x[1])),
         reverse=True):
     if args.debug:
-        print "%s: %d" % (url, count)
+        print("%s: %d" % (url, count))
     fd.write("%s: %d\n" % (url, count))
 fd.write("Hosts older - 2\n")
 
 if args.debug:
-    print "Hosts older - 2"
+    print("Hosts older - 2")
 for url, count in sorted(
         hosts_older_2.items(),
         key=lambda x: (int(x[1])),
         reverse=True):
     if args.debug:
-        print "%s: %d" % (url, count)
+        print("%s: %d" % (url, count))
     fd.write("%s: %d\n" % (url, count))
 
 fd.close()
@@ -327,8 +328,8 @@ plt.savefig(
     bbox_inches='tight')
 
 if args.debug:
-    print("%s-%s-repomd-propagation.pdf" %
-          (args.prefix, labels[len(labels) - 1].split('\n')[0]))
+    print(("%s-%s-repomd-propagation.pdf" %
+          (args.prefix, labels[len(labels) - 1].split('\n')[0])))
 
 plt.savefig("%s-repomd-propagation.pdf" % args.prefix, bbox_inches='tight')
 plt.savefig("%s-repomd-propagation.svg" % args.prefix, bbox_inches='tight')

--- a/utility/mm2_update-EC2-netblocks
+++ b/utility/mm2_update-EC2-netblocks
@@ -4,7 +4,7 @@ Synchronize Amazon AWS-published EC2 netblock lists per region into the
 MirrorManager database for Fedora Infrastructure-managed mirrors in S3.
 """
 
-# std imports
+from __future__ import print_function
 import json
 import optparse
 import os
@@ -66,7 +66,7 @@ def doit(session, dry_run):
             h = hosts_by_region[region]
             host = h['host']
             if not host_has_netblock(hosts_by_region, region, ip_prefix):
-                print "Adding host %s netblock %s" % (host.name, ip_prefix)
+                print("Adding host %s netblock %s" % (host.name, ip_prefix))
                 if not dry_run:
                     nb = HostNetblock(host=host, netblock=ip_prefix, name=None) # this adds the entry to the database, mark as not stale
                     session.add(nb)
@@ -85,7 +85,7 @@ def doit(session, dry_run):
         for netblock in hosts_by_region[region]['netblocks']:
             if hosts_by_region[region]['netblocks'][netblock]['stale']: # delete this, it's no longer on Amazon's list
                 host = h['host']
-                print "Deleting host %s netblock %s" % (host.name, netblock)
+                print("Deleting host %s netblock %s" % (host.name, netblock))
                 if not dry_run:
                     nb = mirrormanager2.lib.get_host_netblock(
                         session,

--- a/utility/mm2_update-master-directory-list
+++ b/utility/mm2_update-master-directory-list
@@ -670,7 +670,7 @@ def sync_category_directories(
 
     # this has to be a second pass to be sure the child repodata/ dir is
     # created in the db first
-    for relativeDName, value in category_directories.iteritems():
+    for relativeDName, value in category_directories.items():
         d = category.directory_cache[relativeDName]
         D = mirrormanager2.lib.get_directory_by_id(session, d.id)
 

--- a/utility/mm2_upgrade-install-repo
+++ b/utility/mm2_upgrade-install-repo
@@ -13,6 +13,7 @@ the UMDL script.
 TODO: test IRL
 """
 
+from __future__ import print_function
 import sys
 import re
 import os
@@ -38,7 +39,7 @@ def move_install_repo(session, version, test=False, debug=False):
         session, product.name, version)
 
     if not ver:
-        print 'No version found for %s-%s' % (product.name, version)
+        print('No version found for %s-%s' % (product.name, version))
         return
 
     for a in mirrormanager2.lib.get_arches(session):
@@ -63,34 +64,34 @@ def move_install_repo(session, version, test=False, debug=False):
 
         if not test:
             if not os.path.isdir(os.path.join('/srv', d)):
-                print "directory %s does not exist on disk, skipping "\
-                    "creation of a repository there" % d
+                print("directory %s does not exist on disk, skipping "
+                      "creation of a repository there" % d)
                 continue
 
         dobj = mirrormanager2.lib.get_directory_by_name(session, d)
 
         if not dobj:
-            print "directory %s exists on disk, but not in the database"\
-                " yet, skipping creation of a repository there until "\
-                "after the next UMDL run." % d
+            print("directory %s exists on disk, but not in the database"
+                  " yet, skipping creation of a repository there until "
+                  "after the next UMDL run." % d)
             continue
 
         repo = mirrormanager2.lib.get_repo_prefix_arch(
             session, prefix, a.name)
         if not repo:
-            print 'No repo found for prefix: %s - arch: %s' % (
-                prefix, a.name)
+            print('No repo found for prefix: %s - arch: %s' % (
+                prefix, a.name))
             continue
 
-        print "Updating %s" % repo
-        print "Updating %s repo for arch %s" % (repo.prefix, a.name)
+        print("Updating %s" % repo)
+        print("Updating %s repo for arch %s" % (repo.prefix, a.name))
 
         if debug:
-            print '%s   becomes   %s' % (repo.version_id, ver.id)
-            print '%s   becomes   %s' % (repo.arch_id, a.id)
-            print '%s   becomes   %s' % (repo.name, dobj.name)
-            print '%s   becomes   %s' % (repo.directory_id, dobj.id)
-            print '%s   becomes   %s' % (repo.category_id, category.id)
+            print('%s   becomes   %s' % (repo.version_id, ver.id))
+            print('%s   becomes   %s' % (repo.arch_id, a.id))
+            print('%s   becomes   %s' % (repo.name, dobj.name))
+            print('%s   becomes   %s' % (repo.directory_id, dobj.id))
+            print('%s   becomes   %s' % (repo.category_id, category.id))
         else:
             repo.version_id = ver.id
             repo.arch_id = a.id


### PR DESCRIPTION
Not everything is converted. Test results:

```
$ py.test-2.7 --tb=no .
================ test session starts ===========================
platform linux2 -- Python 2.7.11, pytest-2.9.2, py-1.4.31, pluggy-0.3.1
rootdir: /var/tmp/mirrormanager2, inifile: 
plugins: cov-2.2.1
collected 126 items 

tests/test_mdtr.py FF
tests/test_mm_lib_model.py ...................
tests/test_mmlib.py ...............................................
tests/test_mta.py F
tests/test_ui_admin.py FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
tests/test_ui_app.py ..FFFFFFFFFFFFF.F.F...F.
tests/test_umdl.py FF
========== 52 failed, 74 passed in 81.31 seconds ===============
```

```
py.test-3.5 --tb=no .
================== test session starts =======================
platform linux -- Python 3.5.1, pytest-2.9.2, py-1.4.31, pluggy-0.3.1
rootdir: /var/tmp/mirrormanager2, inifile: 
plugins: cov-2.2.1
collected 126 items 

tests/test_mdtr.py FF
tests/test_mm_lib_model.py ...................
tests/test_mmlib.py ...............................................
tests/test_mta.py F
tests/test_ui_admin.py FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
tests/test_ui_app.py FFFFFFFFFFFFFFFFFFFFFFFF
tests/test_umdl.py FF
============ 60 failed, 66 passed in 62.26 seconds  =================
```

As you can see, tests import fine under Python 3.5, and there's only a few more failures. A bunch of tests fail because of bytes/str incompatiblity under Python 3. This is in the testing code, and I don't know what the proper solution is, so I left this alone.

mirrorlist/mirrorlist_client.wsgi runs, mirrorlist/mirrorlist_server.py fails with GeoIP import which I can't easy obtain.

Nibbles-away-at #139.
