### PR TITLE
Skip disabled repositories in the overview

### DIFF
--- a/mirrormanager2/lib/model.py
+++ b/mirrormanager2/lib/model.py
@@ -769,6 +769,8 @@ class Version(BASE):
         '''
         arches = set()
         for repo in self.repositories:
+            if repo.disabled:
+                continue
             arches.add(repo.arch.name)
         return arches
 


### PR DESCRIPTION
MirrorManager still picks up old and archived versions of repositories.
This uses the existing disabled flag to ignore those repositories in the
overview.

See https://fedorahosted.org/fedora-infrastructure/ticket/4625

Signed-off-by: Adrian Reber <adrian@lisas.de>