### PR TITLE
mm2_move-devel-to-release: adapt to latest repository layout

### DIFF
--- a/utility/mm2_move-devel-to-release
+++ b/utility/mm2_move-devel-to-release
@@ -49,7 +49,7 @@ def move_devel_repo(session, category, version):
         sys.exit(1)
 
     oldpattern = os.path.join('development', version)
-    newpattern = os.path.join('releases', version, 'Everything')
+    newpattern = os.path.join('releases', version)
     oldRe = re.compile(oldpattern)
     for r in c.repositories:
         if not r.prefix:


### PR DESCRIPTION
mm2_move-devel-to-release was still assuming that the 'releases/'
directory has the 'Everything/' part in it but that 'Everything/' does not
exist under 'development/'. As this has changed this script needs to
adapt to the new layout. Without this change the script was looking for
directories like

pub/fedora-secondary/releases/24/Everything/Everything/ppc64/debug/tree

which do not exist.

Bug report: https://bugzilla.redhat.com/show_bug.cgi?id=1395695

Fixes #195

Signed-off-by: Adrian Reber <adrian@lisas.de>