### PR TITLE
Private URLs are now restricted to admins

### DIFF
--- a/mirrormanager2/app.py
+++ b/mirrormanager2/app.py
@@ -1153,6 +1153,7 @@ def host_category_url_new(host_id, hc_id):
     if form.validate_on_submit():
 
         host_category_u = model.HostCategoryUrl()
+        private = host_category_u.private
         host_category_u.host_category_id = hcobj.id
         form.populate_obj(obj=host_category_u)
 
@@ -1160,6 +1161,10 @@ def host_category_url_new(host_id, hc_id):
         if url.endswith('/'):
             url = url[:-1]
         host_category_u.url = url
+
+        # If the user is *not* an admin, keep the current private flag
+        if not is_mirrormanager_admin(flask.g.fas_user):
+            host_category_u.private = private
 
         SESSION.add(host_category_u)
 

--- a/mirrormanager2/templates/fedora/host_category.html
+++ b/mirrormanager2/templates/fedora/host_category.html
@@ -39,7 +39,7 @@
 <h3>URLs serving this content</h3>
 
 <p>
-  The same content may be served by multiple means: http, ftp, and rsync
+  The same content may be served by multiple means: http, https, and rsync
   are common examples. Content may also be served via a 'private' URL only
   visible to other mirror admins. Such private URLs usually include a
   nonstandard rsync port, and/or a username and password. Admins from Mirror
@@ -64,6 +64,9 @@
           title="Delete url">
           <span class="icon icon-trash blue"></span>
         </button>
+        {%- if urls.private -%}
+          (Private URL - This URL will not show up in the mirrorlist/metalink)
+        {%- endif -%}
     </form>
   </li>
   {% endfor %}

--- a/mirrormanager2/templates/fedora/host_category_url_new.html
+++ b/mirrormanager2/templates/fedora/host_category_url_new.html
@@ -17,8 +17,10 @@
 <form action="{{ url_for('host_category_url_new',
                  host_id=host.id, hc_id=hostcategory.id) }}" method="POST">
   <table>
-    {{ render_field_in_row(form.url) }}
-    {{ render_field_in_row(form.private) }}
+    {{ render_field_in_row(form.url, after='URL (rsync, https, http) pointing to the top directory') }}
+    {%- if is_admin -%}
+      {{ render_field_in_row(form.private, after='A private URL will not show up in the mirrorlist/metalink') }}
+    {%- endif -%}
   </table>
   <p class="buttons indent">
     <input type="submit" class="submit positive button" value="Create">


### PR DESCRIPTION
MirrorManager has the concept of private URLs which should be used
for inter-mirror syncing. Unfortunately they are sometimes confused
with the concept of private mirrors. Private URLs will never show up in
the mirrorlist/metalink and if a private mirror (only for a certain
network or host) marks a URL as private it will not show up.

As the private flag is not reflected anywhere on the web pages it can
only be seen in the database.

With this change a private URL is now also displayed as private in the
host category URL view and only admins can mark URLs as private.

Signed-off-by: Adrian Reber <adrian@lisas.de>