### PR TITLE
Remove 'Master rsync server Access Control List IPs' section

### DIFF
--- a/mirrormanager2/default_config.py
+++ b/mirrormanager2/default_config.py
@@ -96,6 +96,10 @@ SHOW_PROPAGATION = True
 # Where to look for the above mentioned propagation images.
 PROPAGATION_BASE = '/var/www/mirrormanager-statistics/data/propagation'
 
+# Disable master rsync server ACL
+# Fedora does not use it and therefore it is set to False
+MASTER_RSYNC_ACL = False
+
 # When this is set to True, the session cookie will only be returned to the
 # server via ssl (https). If you connect to the server via plain http, the
 # cookie will not be sent. This prevents sniffing of the cookie contents.

--- a/mirrormanager2/templates/fedora/host.html
+++ b/mirrormanager2/templates/fedora/host.html
@@ -82,6 +82,7 @@ Last Crawl Duration: {{ host.last_crawl_duration }} seconds
 {% if host.crawl_failures > 0 %}<br/>Number of consecutive crawl failures: {{ host.crawl_failures }} {% endif %}
 </p>
 
+{%- if config['MASTER_RSYNC_ACL'] -%}
 <h3>
   Master rsync server Access Control List IPs
 </h3>
@@ -111,7 +112,7 @@ Last Crawl Duration: {{ host.last_crawl_duration }} seconds
   {% endfor %}
   </ul>
 {% endif %}
-
+{%- endif -%}{# MASTER_RSYNC_ACL ##}
 
 <h3>
   Site-local Netblocks

--- a/mirrormanager2/templates/fedora/host_acl_ip_new.html
+++ b/mirrormanager2/templates/fedora/host_acl_ip_new.html
@@ -12,6 +12,7 @@
     {{ host.name }}</a>
 </p>
 
+{%- if config['MASTER_RSYNC_ACL'] -%}
 <p>
   These host DNS names and/or IP addresses will be allowed to rsync from the
   master rsync/ftp servers. List here all the machines that you use for
@@ -30,5 +31,6 @@
     {{ form.csrf_token }}
   </p>
 </form>
+{%- endif -%}{# MASTER_RSYNC_ACL ##}
 
 {% endblock %}

--- a/utility/mirrormanager2.cfg.sample
+++ b/utility/mirrormanager2.cfg.sample
@@ -92,6 +92,10 @@ SHOW_PROPAGATION = True
 # Where to look for the above mentioned propagation images.
 PROPAGATION_BASE = '/var/www/mirrormanager-statistics/data/propagation'
 
+# Disable master rsync server ACL
+# Fedora does not use it and therefore it is set to False
+MASTER_RSYNC_ACL = False
+
 # When this is set to True, the session cookie will only be returned to the
 # server via ssl (https). If you connect to the server via plain http, the
 # cookie will not be sent. This prevents sniffing of the cookie contents.


### PR DESCRIPTION
This adds a configuration option to enable/disable the 'Master rsync
server Access Control List IPs' section in the host template. As Fedora
has never (or at least for a long time not) used this functionality this
disables if by default in the Fedora templates.

It could have been completely removed from the Fedora templates, but as
long as the Fedora templates are the only templates I just conditionally
disabled it.

Signed-off-by: Adrian Reber <adrian@lisas.de>