### PR TITLE
mirrorlist: add pkl generation time to pkl

### DIFF
--- a/mirrorlist/mirrorlist_client.wsgi
+++ b/mirrorlist/mirrorlist_client.wsgi
@@ -74,7 +74,7 @@ def real_client_ip(xforwardedfor):
 def request_setup(environ, request):
     fields = [
         'repo', 'arch', 'country', 'path', 'netblock', 'location',
-        'version', 'cc', 'protocol'
+        'version', 'cc', 'protocol', 'time'
     ]
     d = {}
     request_data = request.GET

--- a/mirrorlist/mirrorlist_server.py
+++ b/mirrorlist/mirrorlist_server.py
@@ -692,6 +692,13 @@ def do_mirrorlist(kwargs):
         except:
             pass
 
+    if 'time' in kwargs:
+        try:
+            # Last code modifying the header. Let's enter a newline
+            header += '\n# database creation time: %s' % (database['time'])
+        except:
+            pass
+
     if 'metalink' in kwargs and kwargs['metalink']:
         (resulttype, returncode, results)=metalink(
             cache, dir, file, hosts_and_urls)
@@ -786,6 +793,8 @@ def read_caches():
         info['netblock_country_cache'] = data['netblock_country_cache']
     if 'host_max_connections_cache' in data:
         info['host_max_connections_cache'] = data['host_max_connections_cache']
+    if 'time' in data:
+        info['time'] = data['time']
 
     setup_continents(info)
 

--- a/mirrormanager2/lib/mirrorlist.py
+++ b/mirrormanager2/lib/mirrorlist.py
@@ -19,6 +19,7 @@
 # of Red Hat, Inc.
 #
 
+import datetime
 import os
 import hashlib
 import cPickle as pickle
@@ -389,6 +390,7 @@ def dump_caches(session, filename):
         'hcurl_cache': hcurl_cache(session),
         'location_cache': location_cache(session),
         'netblock_country_cache': netblock_country_cache(session),
+        'time': datetime.datetime.utcnow(),
     }
 
     try:


### PR DESCRIPTION
When the mirrorlist_server.py process is 'kill -1'-ed to reload its
data, the new data is sometimes not reloaded. Once the mirrorlist
process is in such a state only a complete restart seems to help.

This adds an additional GET parameter to query the database generation
time:

 $ curl 'http://localhost/mirrorlist?repo=epel-7&arch=x86_64&country=global&time'
 # repo = epel-7 arch = x86_64 country = global
 # Database creation time: 2017-02-26 20:14:05.942993

Signed-off-by: Adrian Reber <adrian@lisas.de>