### PR TITLE
compress crawler logs in logrotate. They are small, but they add up

### DIFF
--- a/utility/mm2_crawler.logrotate
+++ b/utility/mm2_crawler.logrotate
@@ -5,4 +5,5 @@
     dateext
     rotate 15
     copytruncate
+    compress
 }


### PR DESCRIPTION
compress crawler logs, save us some space on the crawler machines. 🐄 