### PR TITLE
restrict non-admin users to certain netblock sizes

### DIFF
--- a/mirrormanager2/app.py
+++ b/mirrormanager2/app.py
@@ -725,6 +725,7 @@ def host_netblock_new(host_id):
     """ Create a new host_netblock.
     """
     hostobj = mmlib.get_host(SESSION, host_id)
+    flask.g.is_mirrormanager_admin = is_mirrormanager_admin(flask.g.fas_user)
 
     if hostobj is None:
         flask.abort(404, 'Host not found')

--- a/mirrormanager2/default_config.py
+++ b/mirrormanager2/default_config.py
@@ -126,6 +126,12 @@ MM_LOG_DIR = '/var/log/mirrormanager'
 # or setting it to '' removes any protocol restrictions.
 MM_PROTOCOL_REGEX = '^(?!ftp)(.*)$'
 
+# The netblock size parameters define which netblock sizes can be
+# added by a site administrator. Larger networks can only be added by
+# mirrormanager admins.
+MM_IPV4_NETBLOCK_SIZE = '/16'
+MM_IPV6_NETBLOCK_SIZE = '/32'
+
 # If not specified the application will rely on the root_url when sending
 # emails, otherwise it will use this URL
 # Default: ``None``.

--- a/utility/mirrormanager2.cfg.sample
+++ b/utility/mirrormanager2.cfg.sample
@@ -122,6 +122,12 @@ MM_LOG_DIR = '/var/log/mirrormanager'
 # or setting it to '' removes any protocol restrictions.
 MM_PROTOCOL_REGEX = '^(?!ftp)(.*)$'
 
+# The netblock size parameters define which netblock sizes can be
+# added by a site administrator. Larger networks can only be added by
+# mirrormanager admins.
+MM_IPV4_NETBLOCK_SIZE = '/16'
+MM_IPV6_NETBLOCK_SIZE = '/32'
+
 # If not specified the application will rely on the root_url when sending
 # emails, otherwise it will use this URL
 # Default: ``None``.


### PR DESCRIPTION
Backport from mirrormanager1:
https://pagure.io/mirrormanager/blob/master/f/server/mirrormanager/controllers.py#_655

The original mirrormanager implementation restricted IPv4 netblock sizes
to /16 and IPv6 netblock sizes to /32. This is used to prevent mirror
admins to make the whole internet their local netblock.

This change reintroduces the above code from the original mirrormanager
implementation.

Signed-off-by: Adrian Reber <adrian@lisas.de>