### PR TITLE
umdl: delete make_file_details_from_checksums

### DIFF
--- a/utility/mm2_update-master-directory-list
+++ b/utility/mm2_update-master-directory-list
@@ -52,93 +52,6 @@ class MasterFilter(logging.Filter):
         record.category = cname
         return True
 
-def make_file_details_from_checksums(session, diskpath, relativeDName, D):
-    def _parse_checksum_file(relativeDName, checksumlen):
-        r = {}
-        try:
-            f = open(os.path.join(diskpath, relativeDName),  'r')
-            for line in f:
-                line = line.strip()
-                s = line.split()
-                if len(s) < 2:
-                    continue
-                if len(s[0]) != checksumlen:
-                    continue
-                # strip off extraneous starting '*' char from name
-                s[1] = s[1].strip('*')
-                r[s[1]] = s[0]
-            f.close()
-        except:
-            pass
-        return r
-
-    def _checksums_from_globs(relativeDName, globs, checksumlen):
-        d = {}
-        checksum_files = []
-        for g in globs:
-            checksum_files.extend(
-                glob.glob(os.path.join(diskpath, relativeDName, g)))
-        for f in checksum_files:
-            d.update(_parse_checksum_file(f, checksumlen))
-        return d
-
-    if diskpath is None:
-        return
-
-    sha1_globs = ['*.sha1sum', 'SHA1SUM', 'sha1sum.txt']
-    md5_globs = ['*.md5sum', 'MD5SUM', 'md5sum.txt']
-    sha256_globs = ['*-CHECKSUM', 'sha256sum.txt']
-    sha512_globs = ['*.sha512sum', 'SHA512SUM', 'sha512sum.txt']
-    md5dict = _checksums_from_globs(relativeDName, md5_globs, 32)
-    sha1dict = _checksums_from_globs(relativeDName, sha1_globs, 40)
-    sha256dict = _checksums_from_globs(relativeDName, sha256_globs, 64)
-    sha512dict = _checksums_from_globs(relativeDName, sha512_globs, 128)
-
-    files = set()
-    for k in md5dict.keys():
-        files.add(k)
-    for k in sha1dict.keys():
-        files.add(k)
-    for k in sha256dict.keys():
-        files.add(k)
-    for k in sha512dict.keys():
-        files.add(k)
-
-    for f in files:
-        try:
-            s = os.stat(os.path.join(diskpath, relativeDName, f))
-        except OSError:
-            # bail if the file doesn't actually exist
-            continue
-        sha1 = sha1dict.get(f)
-        md5  = md5dict.get(f)
-        sha256  = sha256dict.get(f)
-        sha512  = sha512dict.get(f)
-        size = s.st_size
-        ctime = s[stat.ST_CTIME]
-        fd = mirrormanager2.lib.get_file_detail(
-            session,
-            directory_id=D.id,
-            filename=f,
-            sha1=sha1,
-            md5=md5,
-            sha256=sha256,
-            sha512=sha512,
-            size=size,
-            timestamp=ctime)
-        if not fd:
-            fd = FileDetail(
-                directory=D,
-                filename=f,
-                sha1=sha1,
-                md5=md5,
-                sha256=sha256,
-                sha512=sha512,
-                timestamp=ctime,
-                size=size)
-            session.add(fd)
-            session.commit()
-
 
 def make_repo_file_details(session, diskpath, relativeDName, D, category, target):
 
@@ -476,7 +389,6 @@ def sync_category_directories(
                     D.files = short_filelist(value['files'])
         session.add(D)
         session.commit()
-        make_file_details_from_checksums(session, diskpath, relativeDName, D)
 
     # this has to be a second pass to be sure the child repodata/ dir is
     # created in the db first


### PR DESCRIPTION
The function make_file_details_from_checksums() looks for certain files
which contain the checksums for other files. This is (better was) used
to store the checksums of the ISOs in the database. Looking right now
at the file_details table there are about 3000 entries and 900 are
checksums for other files than repomd.xml. The checksums for files which
are not repomd.xml are not used anywhere and therefore not required to
be in the database at all.

Additionally the function make_file_details_from_checksums() is broken
since Fedora 21 as the format of the checksum file
(Fedora-Server-22-x86_64-CHECKSUM) has changed to:

SHA256 (Fedora-Server-DVD-x86_64-22.iso) = b2acfa7c7c6b5d2f51d3337600c2e52eeaa1a1084991181c28ca30343e52e0df

This format is not understood by the function
make_file_details_from_checksums(). Since Fedora 22 no new checksums
have been added to database and nobody seems to miss it. Therefore this
patch removes all the make_file_details_from_checksums() code.

Signed-off-by: Adrian Reber <adrian@lisas.de>