### PR TITLE
Change all references from fedorahosted.org to use the github area.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,11 +8,10 @@ MirrorManager is the application that keeps track of the nearly 400 public mirro
 and over 300 private mirrors, that carry Fedora, EPEL, and RHEL content, and is used
 by rpmfusion.org, a third party repository. It automatically selects the "best"
 mirror for a given user based on a set of fallback heuristics.
-For more details `mirrormanager <https://fedorahosted.org/mirrormanager/>`_
 
 :Github mirror: https://github.com/fedora-infra/mirrormanager2
-:Mailing list for announcements: http://www.redhat.com/mailman/listinfo/mirror-list
-:Mailing list for discussions: http://www.redhat.com/mailman/listinfo/mirror-list-d
+:Mailing list for announcements and discussions: 
+https://lists.fedoraproject.org/archives/list/mirror-admin@lists.fedoraproject.org/
 
 Hacking
 -------

--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -15,5 +15,4 @@ If you're submitting patches to MirrorManager2, please observe the following:
    idea but don't know how to implement it, you just have something bugging
    you?
 
-   Come to see us on IRC: ``#fedora-apps`` on irc.freenode.net or via the
-   `trac of the project <http://fedorahosted.org/packagedb/>`_.
+   Come to see us on IRC: ``#fedora-apps`` on irc.freenode.net

--- a/doc/development.rst
+++ b/doc/development.rst
@@ -8,13 +8,13 @@ Anonymous:
 
 ::
 
-  git clone http://git.fedorahosted.org/git/mirrormanager2.git
+  git clone https://github.com/fedora-infra/mirrormanager2.git
 
 Contributors:
 
 ::
 
-  git clone ssh://<FAS user>@git.fedorahosted.org/git/mirrormanager2.git
+  git clone git@github.com:fedora-infra/mirrormanager2.git
 
 
 Dependencies

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -8,12 +8,11 @@ manage their mirrors.
 
 Resources:
 
-- `Home page <http://fedorahosted.org/mirrormanager/>`_
+- `Home page <https://github.com/fedora-infra/mirrormanager2/>`_
 - `Documentation <http://mirrormanager.rtfd.org/>`_
-- `Git repository <http://git.fedorahosted.org/git/mirrormanager2>`_
-- `Github mirror <https://github.com/fedora-infra/mirrormanager2>`_
+- `Git repository <https://github.com/fedora-infra/mirrormanager2.git>`_
 - `Discussion mailing-list
-  <http://www.redhat.com/mailman/listinfo/mirror-list-d>`_
+  <https://lists.fedoraproject.org/archives/list/mirror-admin@lists.fedoraproject.org/>`_
 
 
 Contents:

--- a/mirrorlist/mirrorlist_server.py
+++ b/mirrorlist/mirrorlist_server.py
@@ -107,7 +107,7 @@ def metalink_header():
     doc += ' type="dynamic"'
     doc += ' pubdate="%s"' % pubdate
     doc += ' generator="mirrormanager"'
-    doc += ' xmlns:mm0="http://fedorahosted.org/mirrormanager"'
+    doc += ' xmlns:mm0="https://github.com/fedora-infra/mirrormanager2/"'
     doc += '>\n'
     return doc
 

--- a/mirrormanager2/templates/fedora/admin/admin_master.html
+++ b/mirrormanager2/templates/fedora/admin/admin_master.html
@@ -81,7 +81,7 @@
 
         <p id="footer">
           Copyright &copy; 2014 Red Hat
-          <a href="https://fedorahosted.org/mirrormanager/">mirrormanager</a>
+          <a href="https://github.com/fedora-infra/mirrormanager2/">mirrormanager</a>
           -- {{version}}
           -- <a href="http://mirrormanager.rtfd.org" rel="noopener noreferrer"
                 target="_blank">Documentation</a>

--- a/mirrormanager2/templates/fedora/master_noauth.html
+++ b/mirrormanager2/templates/fedora/master_noauth.html
@@ -63,7 +63,7 @@
 
         <p id="footer">
           Copyright &copy; 2014-2016 Red Hat
-          <a href="https://fedorahosted.org/mirrormanager/">mirrormanager</a>
+          <a href="https://github.com/fedora-infra/mirrormanager2/">mirrormanager</a>
           -- {{version}}
           -- <a href="http://mirrormanager.rtfd.org" rel="noopener noreferrer"
                 target="_blank">Documentation</a>

--- a/setup.py
+++ b/setup.py
@@ -47,8 +47,8 @@ setup(
     maintainer='Pierre-Yves Chibon',
     maintainer_email='pingou@pingoured.fr',
     license='MIT',
-    download_url='https://fedorahosted.org/releases/m/i/mirrormanager/',
-    url='https://fedorahosted.org/mirrormanager/',
+    download_url='https://github.com/fedora-infra/mirrormanager2/releases',
+    url='https://github.com/fedora-infra/mirrormanager2/',
     packages=['mirrormanager2'],
     include_package_data=True,
     install_requires=get_requirements() + get_requirements(

--- a/utility/mirrormanager2.spec
+++ b/utility/mirrormanager2.spec
@@ -10,8 +10,8 @@ Summary:        Mirror management application
 # imported/derivated parts like zebra-dump-parser or the the script
 # to generate the worldmaps are licensed under GPLv2 and GPLv2+
 License:        MIT and GPLv2+ and GPLv2
-URL:            http://fedorahosted.org/mirrormanager/
-Source0:        https://fedorahosted.org/releases/m/i/mirrormanager/%{name}-%{version}.tar.gz
+URL:            https://github.com/fedora-infra/mirrormanager2/
+Source0:        https://github.com/fedora-infra/mirrormanager2/archive/%{version}.tar.gz
 
 BuildArch:      noarch
 

--- a/utility/mm2_crawler
+++ b/utility/mm2_crawler
@@ -593,7 +593,7 @@ def check_head(hoststate, url, filedata, recursion, readable, retry=0):
     conn.request('HEAD', reqpath,
                  headers={'Connection':'Keep-Alive',
                           'Pragma':'no-cache',
-                          'User-Agent':'mirrormanager-crawler/0.1 (+http://fedorahosted.org/mirrormanager)'})
+                          'User-Agent':'mirrormanager-crawler/0.1 (+https://github.com/fedora-infra/mirrormanager2/)'})
 
     r = None
     try:


### PR DESCRIPTION
Note that we will have to change this all again when we move to pagure.