### PR TITLE
Revert namespace change - this breaks namespace aware xml parsers

### DIFF
--- a/mirrorlist/mirrorlist_server.py
+++ b/mirrorlist/mirrorlist_server.py
@@ -107,7 +107,7 @@ def metalink_header():
     doc += ' type="dynamic"'
     doc += ' pubdate="%s"' % pubdate
     doc += ' generator="mirrormanager"'
-    doc += ' xmlns:mm0="https://github.com/fedora-infra/mirrormanager2/"'
+    doc += ' xmlns:mm0="http://fedorahosted.org/mirrormanager"'
     doc += '>\n'
     return doc
 


### PR DESCRIPTION
This reverts a small part of dad4e76899b28755c39d4f494f618a5a4037ebf7.
Changing the XML namespace needs to be more coordinated.

Signed-off-by: Patrick Uiterwijk <patrick@puiterwijk.org>