### PR TITLE
detect and setup mirrorlist/metalinks for modular Fedora

### DIFF
--- a/mirrormanager2/lib/repomap.py
+++ b/mirrormanager2/lib/repomap.py
@@ -27,6 +27,7 @@ def repo_prefix(path, category, ver):
     # assign shortnames to repositories like yum default mirrorlists expects
     isDebug = u'debug' in path
     isRawhide = u'rawhide' in path
+    isBikeshed = u'bikeshed' in path
     isDevelopment = is_development(path) is not None
     isSource = u'source' in path or u'SRPMS' in path
     isUpdatesTesting = u'updates/testing' in path
@@ -38,6 +39,8 @@ def repo_prefix(path, category, ver):
     isAtomic = u'atomic' in path
     isEverything = u'Everything' in path
     isFedora = u'Fedora' in path
+    isServer = u'Server' in path
+    isModular = u'modular' in path
 
 
     isEpel = (category.name == u'Fedora EPEL')
@@ -76,9 +79,9 @@ def repo_prefix(path, category, ver):
             else:
                 prefix = u'epel-%s' % version
 
-    elif isFedoraLinux or isFedoraSecondary or isFedoraArchive:
+    elif isFedoraLinux or isFedoraSecondary or isFedoraArchive or isModularFedoraLinux:
         if isReleases or isDevelopment:
-            if isEverything:
+            if isEverything and not isModular:
                 if isRawhide:
                     # rawhide
                     if isDebug:
@@ -94,7 +97,7 @@ def repo_prefix(path, category, ver):
                     prefix = u'fedora-source-%s' % version
                 else:
                     prefix=u'fedora-%s' % version
-            elif isFedora:
+            elif isFedora and not isModular:
                 if isDebug or isSource:
                     # ignore releases/$version/Fedora/$arch/debug/
                     # ignore releases/$version/Fedora/source/SRPMS/
@@ -102,25 +105,65 @@ def repo_prefix(path, category, ver):
                 else:
                     # fedora-install-
                     prefix = u'fedora-install-%s' % version
+            elif isModular:
+                if isBikeshed:
+                    # Modular Bikeshed
+                    if isServer:
+                        if isDebug:
+                            prefix = u'modular-bikeshed-server-debug'
+                        elif isSource:
+                            prefix = u'modular-bikeshed-server-source'
+                        else:
+                            prefix = u'modular-bikeshed-server'
+                else:
+                    #Modular Releases
+                    if isServer:
+                        if isDebug:
+                            prefix = u'modular-fedora-server-debug'
+                        elif isSource:
+                            prefix = u'modular-fedora-server-source'
+                        else:
+                            prefix = u'modular-fedora-server'
+
         elif isAtomic:
             # atomic
             prefix = u'atomic-%s' % version
         elif isUpdatesReleased:
-            # updates-released-
-            if isDebug:
-                prefix = u'updates-released-debug-f%s' % version
-            elif isSource:
-                prefix = u'updates-released-source-f%s' % version
+            if isModular:
+                if isServer:
+                    # Modular Server updates-released-
+                    if isDebug:
+                        prefix = u'modular-server-updates-released-debug-f%s' % version
+                    elif isSource:
+                        prefix = u'modular-server-updates-released-source-f%s' % version
+                    else:
+                        prefix = u'modular-server-updates-released-f%s' % version
             else:
-                prefix = u'updates-released-f%s' % version
+                # updates-released-
+                if isDebug:
+                    prefix = u'updates-released-debug-f%s' % version
+                elif isSource:
+                    prefix = u'updates-released-source-f%s' % version
+                else:
+                    prefix = u'updates-released-f%s' % version
         elif isUpdatesTesting:
-            # updates-testing-
-            if isDebug:
-                prefix = u'updates-testing-debug-f%s' % version
-            elif isSource:
-                prefix = u'updates-testing-source-f%s' % version
+            if isModular:
+                if isServer:
+                    # Modular Server updates-testing
+                    if isDebug:
+                        prefix = u'modular-server-updates-testing-debug-f%s' % version
+                    elif isSource:
+                        prefix = u'modular-server-updates-testing-source-f%s' % version
+                    else:
+                        prefix = u'modular-server-updates-testing-f%s' % version
             else:
-                prefix = u'updates-testing-f%s' % version
+                # updates-testing-
+                if isDebug:
+                    prefix = u'updates-testing-debug-f%s' % version
+                elif isSource:
+                    prefix = u'updates-testing-source-f%s' % version
+                else:
+                    prefix = u'updates-testing-f%s' % version
         elif isRawhide:
             # rawhide
             if isDebug:


### PR DESCRIPTION
in the new Modular world we need to setup a new structure for
delivering content. it will look something like bellow

/pub/fedora/linux/modular/
/pub/fedora/linux/modular/development
/pub/fedora/linux/modular/development/bikeshed
/pub/fedora/linux/modular/development/27
/pub/fedora/linux/modular/releases
/pub/fedora/linux/modular/releases/test
/pub/fedora/linux/modular/updates
/pub/fedora/linux/modular/updates/27
/pub/fedora/linux/modular/updates/testing
/pub/fedora/linux/modular/updates/testing/27

under each releasever 27, 28 bikeshed etc will be a directory for
the consumable product Server, Workstation, Atomic, etc. For each
consumable product we will have to setup a new set of prefixes. We
are starting with Server.

Signed-off-by: Dennis Gilmore <dennis@ausil.us>