### PR TITLE
umdl: fix 'modular' repository detection

### DIFF
--- a/mirrormanager2/lib/repomap.py
+++ b/mirrormanager2/lib/repomap.py
@@ -79,8 +79,8 @@ def repo_prefix(path, category, ver):
             else:
                 prefix = u'epel-%s' % version
 
-    elif isFedoraLinux or isFedoraSecondary or isFedoraArchive or isModularFedoraLinux:
-        if isReleases or isDevelopment:
+    elif isFedoraLinux or isFedoraSecondary or isFedoraArchive:
+        if isReleases or isDevelopment or isModular:
             if isEverything and not isModular:
                 if isRawhide:
                     # rawhide

--- a/utility/mm2_update-master-directory-list
+++ b/utility/mm2_update-master-directory-list
@@ -603,9 +603,14 @@ def sync_category_directory(
         # directories. This should leave 'Everything' as the directory
         # which is used to create the repository.
         # This is not the most flexible implementation.
+
+        # Too make it even 'nicer' this list of directories to skip
+        # is not relevant for the 'modular' directory tree.
         skip_dir = [ u'Cloud', u'Workstation', u'Server' ]
-        if not any(x in relativeDName for x in skip_dir):
-            umdl.make_repository(session, D, relativeDName, category, 'repomd.xml')
+        if ((not any(x in relativeDName for x in skip_dir)) or
+                ('modular' in relativeDName)):
+            umdl.make_repository(
+                session, D, relativeDName, category, 'repomd.xml')
 
     if ('repomd.xml' in files) and (set_ctime or created):
         umdl.make_repo_file_details(


### PR DESCRIPTION
The 'modular' repository detection from PR #220 needed some fixes.

The repository detection was not entirely correct (some ifs at the wrong
level) and a newly merged feature to not create repositories for
('Cloud', 'Server', 'Workstation') blocked the creation of the modular
Server repository (PR #219).

Signed-off-by: Adrian Reber <adrian@lisas.de>