### PR TITLE
publiclist: hide disabled arches and products

### DIFF
--- a/mirrormanager2/app.py
+++ b/mirrormanager2/app.py
@@ -192,8 +192,10 @@ def inject_variables():
 def index():
     """ Displays the index page.
     """
-    products = mmlib.get_products(SESSION)
-    arches = mmlib.get_arches(SESSION)
+    # publiclist=True filters out all results which have
+    # publiclist set to False
+    products = mmlib.get_products(SESSION, publiclist=True)
+    arches = mmlib.get_arches(SESSION, publiclist=True)
     arches_name = [arch.name for arch in arches]
 
     return flask.render_template(

--- a/mirrormanager2/lib/__init__.py
+++ b/mirrormanager2/lib/__init__.py
@@ -529,10 +529,11 @@ def get_product_by_name(session, p_name):
     return query.first()
 
 
-def get_products(session):
+def get_products(session, publiclist=None):
     ''' Return the list of all the products in the database.
 
     :arg session: the session with which to connect to the database.
+    :arg publiclist: if the result should be filtered by the publiclist column
 
     '''
     query = session.query(
@@ -540,6 +541,9 @@ def get_products(session):
     ).order_by(
         model.Product.name
     )
+
+    if publiclist is not None:
+        query = query.filter(model.Product.publiclist == publiclist)
 
     return query.all()
 
@@ -631,10 +635,11 @@ def get_reporedirect(session):
     return query.all()
 
 
-def get_arches(session):
+def get_arches(session, publiclist=None):
     ''' Return the list of all the arch in the database.
 
     :arg session: the session with which to connect to the database.
+    :arg publiclist: if the result should be filtered by the publiclist column
 
     '''
     query = session.query(
@@ -642,6 +647,9 @@ def get_arches(session):
     ).order_by(
         model.Arch.name
     )
+
+    if publiclist is not None:
+        query = query.filter(model.Arch.publiclist == publiclist)
 
     return query.all()
 


### PR DESCRIPTION
The original MirrorManager code base had the feature to hide certain
arches and products from the publiclist. The database fields still exist
and are even set to 'false' for certain arches.

There is the ticket https://pagure.io/fedora-infrastructure/issue/5186
which tried to remove unused architectures from the publiclist
(sparc and sparc64). Using the now unused database column 'publiclist'
seems like the right thing to do to hide certain arches (including
source) from the publiclist. RPM Fusion which still uses the original
MirrorManager code base is a good example how it used to look:

 http://mirrors.rpmfusion.org/mm/publiclist/

The architecture 'source' is not displayed, which has in both instances
(Fedora and RPM Fusion) publiclist = False. It still can be seen in
Fedora:

 https://admin.fedoraproject.org/mirrormanager/

I tested my changes in Fedora's staging instance and marked sparc,
sparc64 and ia64 as publiclist=false in the database:

 https://admin.stg.fedoraproject.org/mirrormanager/

Signed-off-by: Adrian Reber <adrian@lisas.de>