### PR TITLE
crawler: use timeout also on rsync crawls

### DIFF
--- a/mirrormanager2/lib/sync.py
+++ b/mirrormanager2/lib/sync.py
@@ -29,6 +29,7 @@ import tempfile
 import errno
 import threading
 
+
 def check_timeout(logger, p, timeout, e):
     ''' Check if the process is running and kill it if so. '''
 

--- a/mirrormanager2/lib/sync.py
+++ b/mirrormanager2/lib/sync.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright © 2014  Red Hat, Inc.
+# Copyright © 2017  Adrian Reber
 #
 # This copyrighted material is made available to anyone wishing to use,
 # modify, copy, or redistribute it subject to the terms and conditions

--- a/mirrormanager2/lib/sync.py
+++ b/mirrormanager2/lib/sync.py
@@ -31,7 +31,17 @@ import threading
 
 
 def check_timeout(logger, p, timeout, e):
-    ''' Check if the process is running and kill it if so. '''
+    """
+    Check if the process is running and kill it if it running
+    longer than the specified timeout.
+
+    :param logger: If a logger is available it will be used for messages
+    :param p: The process handle representing the rsync process
+    :param timeout: The timeout after which the rsync process should
+                    definitely end. Will be p.kill()-ed.
+    :param e: The threading.Event() object used to wait for the end of
+              rsync process
+    """
 
     e.wait(timeout)
 
@@ -49,6 +59,21 @@ def check_timeout(logger, p, timeout, e):
 
 
 def run_rsync(rsyncpath, extra_rsync_args=None, logger=None, timeout=None):
+    """
+    This functions runs 'rsync' on :rsyncpath: and returns the output listing
+    as a file descriptor pointing to a tempfile.SpooledTemporaryFile().
+    It is used in the crawler and umdl and aborts after :timeout: if specified.
+
+    :param rsyncpath: The path 'rsync' should use to do a recursive listing.
+                      This can be anything 'rsync' accepts.
+    :param extra_rsync_args: Additional parameters added to 'rsync' like
+                             excludes or includes or anything else.
+    :param logger: If a logger is available it will be used for messages
+    :param timeout: The timeout after which the rsync process should
+                    definitely end. Will be p.kill()-ed.
+    :returns: return code, file descriptor
+    """
+
     tmpfile = tempfile.SpooledTemporaryFile()
     cmd = "rsync --temp-dir=/tmp -r --exclude=.snapshot --exclude='*.~tmp~'"
     if extra_rsync_args is not None:

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -1,0 +1,116 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright © 2017  Adrian Reber
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions
+# of the GNU General Public License v.2, or (at your option) any later
+# version.  This program is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY expressed or implied, including the
+# implied warranties of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+# PURPOSE.  See the GNU General Public License for more details.  You
+# should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+'''
+mirrormanager2 tests for the crawler.
+'''
+
+__requires__ = ['SQLAlchemy >= 0.7']
+import pkg_resources
+
+import unittest
+import subprocess
+import sys
+import os
+
+
+sys.path.insert(0, os.path.join(os.path.dirname(
+    os.path.abspath(__file__)), '..'))
+
+import mirrormanager2.lib
+from mirrormanager2.lib.sync import run_rsync
+import tests
+
+
+FOLDER = os.path.dirname(os.path.abspath(__file__))
+
+
+class CrawlerTest(tests.Modeltests):
+    """ Crawler tests. """
+
+    def setUp(self):
+        """ Set up the environnment, ran before every test. """
+        super(CrawlerTest, self).setUp()
+
+    def test_run_rsync(self):
+        """ Test the run_rsync function"""
+
+        # Test timeout if timeout works
+
+        # Travis needs a really small timeout value
+        result, fd = run_rsync('/', timeout=0.5)
+        fd.close()
+        self.assertEqual(result, -9)
+
+        # Test if timeout does not trigger
+        result, fd = run_rsync('.', timeout=10)
+        fd.close()
+        self.assertNotEqual(result, -9)
+
+        # Test with non-existing directory
+        result, fd = run_rsync('this-is-not-here-i-hope--')
+        fd.close()
+        self.assertEqual(result, 23)
+        self.assertNotEqual(result, 0)
+
+        # Test the 'normal' usage
+        dest = FOLDER + "/../testdata/"
+        result, fd = run_rsync(dest)
+        self.assertEqual(result, 0)
+        output = ''
+        while True:
+            line = fd.readline()
+            if not line:
+                break
+            output += line
+
+        fd.close()
+
+        # Check that atomic is not excluded (see below)
+        self.assertTrue('atomic' in output)
+
+        for i in [
+                '20/Live/x86_64/Fedora-Live-x86_64-20-CHECKSUM',
+                'pub/fedora/linux/releases/20/Fedora/',
+                'releases/20/Fedora/source/SRPMS/a/aalib-1.4.0-0.23',
+                '69a69a59e169ad7d440fbb97d1e917724bb325f96.dirtree',
+                'pub/fedora/linux/atomic/21/objects/04',
+                'pub/fedora/linux/development/22/x86_64/os/repodata'
+        ]:
+            self.assertTrue(i in output)
+
+        # Test the 'extra_rsync_args'
+        extra = '--exclude *atomic*'
+        result, fd = run_rsync(dest, extra)
+        self.assertEqual(result, 0)
+        output = ''
+        while True:
+            line = fd.readline()
+            if not line:
+                break
+            output += line
+
+        fd.close()
+
+        # Check that atomic is excluded
+        self.assertFalse('atomic' in output)
+
+        # Check that non-atomic is still included
+        self.assertTrue('fedora/linux/development/22/' in output)
+
+
+if __name__ == '__main__':
+    SUITE = unittest.TestLoader().loadTestsFromTestCase(CrawlerTest)
+    unittest.TextTestRunner(verbosity=10).run(SUITE)

--- a/utility/mm2_crawler
+++ b/utility/mm2_crawler
@@ -863,10 +863,20 @@ def try_per_category(
 
     timeout_check()
 
+    # Get remaining time this crawl thread has
+    delta = time.time() - threadlocal.starttime
+    # Give the rsync process 90% of the remaining time to finish
+    # the listing of the available files. 90% could already be too
+    # much as updating the status of all scanned directories in the
+    # database usually takes quite some time. But there are more
+    # timeout checks all over the crawler code to make sure we are
+    # not over the timeout.
+    timeout = int(delta * 0.9)
+
     rsync_start_time = datetime.datetime.utcnow()
     params = config.get('CRAWLER_RSYNC_PARAMETERS', '--no-motd')
     try:
-        result, listing = run_rsync(url, params, logger)
+        result, listing = run_rsync(url, params, logger, timeout)
     except:
         logger.exception('Failed to run rsync.', exc_info = True)
         return False


### PR DESCRIPTION
Over two years ago PR #134 added support to abort the rsync based crawls if it takes too long. This commit now uses this existing timeout support to the crawler. The timeout is set to 90% of the remaining crawl time for the current host. This is also related to #77.
