### PR TITLE
travis: added .travis.yml for automatic testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,34 @@
+language: c
+sudo: required
+
+env:
+  - DISTRO="centos:7"
+  - DISTRO="fedora:latest"
+  - DISTRO="fedora:rawhide"
+
+matrix:
+  allow_failures:
+    - env: DISTRO="fedora:rawhide"
+
+before_install:
+  - sudo docker pull ${DISTRO}
+
+install:
+  - sudo docker run --detach --volume="${PWD}":/tmp/test --name `sed -e "s,:,-," <<< ${DISTRO}` ${DISTRO} sleep 600
+  - |
+    sudo docker exec `sed -e "s,:,-," <<< ${DISTRO}` \
+    bash -c 'dnf -y install yum; \
+    yum -y install epel-release; \
+    yum -y install yum-utils rsync && \
+    cd /tmp/test && \
+    yum-builddep -y utility/mirrormanager2.spec && \
+    yum -y install python2-mock python2-nose python-blinker python-nose python2-fedmsg-core; \
+    yum -y install python-coverage; \
+    dnf -y install python2-coverage; \
+    exit 0'
+
+script:
+  - sudo docker exec `sed -e "s,:,-," <<< ${DISTRO}` bash -c 'cd /tmp/test && ./runtests.sh'
+
+after_script:
+  - sudo docker stop `sed -e "s,:,-," <<< ${DISTRO}`


### PR DESCRIPTION
Use containers to test MirrorManager2 in centos:7, fedora:latest and
fedora:rawhide

Signed-off-by: Adrian Reber <adrian@lisas.de>