### PR TITLE
fix flask.ext deprecation warnings

### DIFF
--- a/mirrormanager2/admin.py
+++ b/mirrormanager2/admin.py
@@ -24,12 +24,8 @@ MirrorManager2 admin flask controller.
 '''
 
 import flask
-from flask.ext.admin import BaseView, expose
-try:
-    from flask.ext.admin.contrib.sqla import ModelView
-except ImportError:  # pragma: no cover
-    # The module was renamed in flask-admin
-    from flask.ext.admin.contrib.sqlamodel import ModelView
+from flask_admin import BaseView, expose
+from flask_admin.contrib.sqla import ModelView
 
 from mirrormanager2.app import APP, ADMIN, SESSION, is_mirrormanager_admin
 from mirrormanager2.lib import model

--- a/mirrormanager2/app.py
+++ b/mirrormanager2/app.py
@@ -35,7 +35,7 @@ import werkzeug
 import flask
 
 from functools import wraps
-from flask.ext.admin import Admin
+from flask_admin import Admin
 from sqlalchemy.exc import SQLAlchemyError
 
 from mirrormanager2 import __version__
@@ -89,7 +89,7 @@ LOG = APP.logger
 if APP.config.get('MM_AUTHENTICATION') == 'fas':
     # Use FAS for authentication
     try:
-        from flask.ext.fas_openid import FAS
+        from flask_fas_openid import FAS
         FAS = FAS(APP)
     except ImportError:
         APP.logger.exception("Couldn't import flask-fas-openid")

--- a/mirrormanager2/forms.py
+++ b/mirrormanager2/forms.py
@@ -34,7 +34,7 @@ MirrorManager2 forms.
 
 
 import re
-from flask.ext import wtf
+import flask_wtf as wtf
 import wtforms
 from flask import g
 

--- a/mirrormanager2/login.py
+++ b/mirrormanager2/login.py
@@ -27,12 +27,8 @@ import hashlib
 import datetime
 
 import flask
-from flask.ext.admin import BaseView, expose
-try:
-    from flask.ext.admin.contrib.sqla import ModelView
-except ImportError:
-    # The module was renamed in flask-admin
-    from flask.ext.admin.contrib.sqlamodel import ModelView
+from flask_admin import BaseView, expose
+from flask_admin.contrib.sqla import ModelView
 from sqlalchemy.exc import SQLAlchemyError
 
 import mirrormanager2.login_forms as forms

--- a/mirrormanager2/login_forms.py
+++ b/mirrormanager2/login_forms.py
@@ -33,7 +33,7 @@ MirrorManager2 login forms.
 # pylint: disable=W0232
 
 
-from flask.ext import wtf
+import flask_wtf as wtf
 import wtforms
 
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -45,7 +45,7 @@ def user_set(APP, user):
     """ Set the provided user as fas_user in the provided application."""
 
     # Hack used to remove the before_request function set by
-    # flask.ext.fas_openid.FAS which otherwise kills our effort to set a
+    # flask_fas_openid.FAS which otherwise kills our effort to set a
     # flask.g.fas_user.
     APP.before_request_funcs[None] = []
 


### PR DESCRIPTION
Running the test cases on Fedora showed a few flask.ext deprecation
warnings. With this commit those are fixed by using flask_admin or
flask_wtf. Even if RHEL/CentOS does not show the deprecation warnings
the newer names also work there.

Signed-off-by: Adrian Reber <adrian@lisas.de>