### PR TITLE
tests: fix broken test results

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,17 +15,7 @@ before_install:
 
 install:
   - sudo docker run --detach --volume="${PWD}":/tmp/test --name `sed -e "s,:,-," <<< ${DISTRO}` ${DISTRO} sleep 600
-  - |
-    sudo docker exec `sed -e "s,:,-," <<< ${DISTRO}` \
-    bash -c 'dnf -y install yum; \
-    yum -y install epel-release; \
-    yum -y install yum-utils rsync && \
-    cd /tmp/test && \
-    yum-builddep -y utility/mirrormanager2.spec && \
-    yum -y install python2-mock python2-nose python-blinker python-nose python2-fedmsg-core; \
-    yum -y install python-coverage; \
-    dnf -y install python2-coverage; \
-    exit 0'
+  - tests/setup_test_container.sh ${DISTRO}
 
 script:
   - sudo docker exec `sed -e "s,:,-," <<< ${DISTRO}` bash -c 'cd /tmp/test && ./runtests.sh'

--- a/tests/setup_test_container.sh
+++ b/tests/setup_test_container.sh
@@ -1,0 +1,33 @@
+#!/bin/bash -x
+
+if [ $# -ne 1 ]; then
+	echo "${0} requires distro name as parameter."
+	exit 1
+fi
+
+echo "Installing for ${1}"
+
+env
+
+if [[ "${1}" == cento* ]]; then
+	export PKG=yum
+	export BUILDDEP=yum-builddep
+else
+	export PKG=dnf
+	export BUILDDEP='dnf builddep'
+fi
+
+sudo docker exec `sed -e "s,:,-," <<< ${1}` \
+	bash -c "if [[ \"${1}\" == cento* ]]; then \
+		${PKG} -y install epel-release yum-utils; \
+	else \
+		${PKG} -y install dnf-plugins-core; \
+	fi; \
+	${PKG} -y install yum rsync rpm-build && \
+	cd /tmp/test && \
+	${BUILDDEP} -y utility/mirrormanager2.spec && \
+	${PKG} -y install python2-mock python2-nose python-blinker python-nose python2-fedmsg-core; \
+	${PKG} -y install python-coverage; \
+	${PKG} -y install python2-coverage; \
+	exit 0"
+

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -50,7 +50,7 @@ class CrawlerTest(tests.Modeltests):
         # Test timeout if timeout works
 
         # Travis needs a really small timeout value
-        result, fd = run_rsync('/', timeout=0.5)
+        result, fd = run_rsync('/', timeout=0.05)
         fd.close()
         self.assertEqual(result, -9)
 


### PR DESCRIPTION
The container setup to run the tests on centos-7 fedora-rawhide and
fedora-latest was using yum to install the packages on all systems as
that made it possible to install all three test scenarios with one
command. This no longer works as rich dependencies are not resolved by
yum and thus the test environment could no longer be correctly set up.

This commit introduces a shell script to set up the container based on
the ${DISTRO}.

Another change is to decrease the timeout for the timeout run_rsync test
case.

Signed-off-by: Adrian Reber <adrian@lisas.de>