### PR TITLE
Use "site", "host" and "mirror" consistently

### DIFF
--- a/mirrormanager2/forms.py
+++ b/mirrormanager2/forms.py
@@ -98,7 +98,7 @@ class AddSiteForm(wtf.Form):
 class AddHostForm(wtf.Form):
     """ Form to add or edit a host. """
     name = wtforms.TextField(
-        'Site name  <span class="error">*</span>',
+        'Host name  <span class="error">*</span>',
         [wtforms.validators.Required()]
     )
     admin_active = wtforms.BooleanField(

--- a/mirrormanager2/templates/fedora/my_sites.html
+++ b/mirrormanager2/templates/fedora/my_sites.html
@@ -26,7 +26,7 @@
 <table>
   <tr>
     <th>Site name</th>
-    <th>Mirror</th>
+    <th>Hosts</th>
     <th>Admin Active</th>
     <th>User Active</th>
     <th>Private</th>


### PR DESCRIPTION
The terms "site" and "host" have a special meaning in MirrorManager. One
'Site' can consist of multiple 'Host's but the terms were not used
consistently. This tries to address that by renaming 'Site name' in the
host to 'Host name' and by renaming 'Mirror' to 'Hosts' when showing the
overview.

Signed-off-by: Adrian Reber <adrian@lisas.de>