### PR TITLE
repomap: modular changes for Fedora 28

### DIFF
--- a/mirrormanager2/lib/repomap.py
+++ b/mirrormanager2/lib/repomap.py
@@ -104,22 +104,6 @@ def repo_prefix(path, category, ver):
                 else:
                     # fedora-install-
                     prefix = u'fedora-install-%s' % version
-            elif isUpdatesReleased:
-                # updates-released-
-                if isDebug:
-                    prefix = u'updates-released-debug-f%s' % version
-                elif isSource:
-                    prefix = u'updates-released-source-f%s' % version
-                else:
-                    prefix = u'updates-released-f%s' % version
-            elif isUpdatesTesting:
-                # updates-testing-
-                if isDebug:
-                    prefix = u'updates-testing-debug-f%s' % version
-                elif isSource:
-                    prefix = u'updates-testing-source-f%s' % version
-                else:
-                    prefix = u'updates-testing-f%s' % version
         elif isModular:
             if isUpdatesReleased:
                 # updates-released-modular-
@@ -156,7 +140,7 @@ def repo_prefix(path, category, ver):
         elif isAtomic:
             # atomic
             prefix = u'atomic-%s' % version
-        elif isUpdatesReleased:
+        elif isUpdatesReleased and isEverything:
             # updates-released-
             if isDebug:
                 prefix = u'updates-released-debug-f%s' % version
@@ -164,7 +148,7 @@ def repo_prefix(path, category, ver):
                 prefix = u'updates-released-source-f%s' % version
             else:
                 prefix = u'updates-released-f%s' % version
-        elif isUpdatesTesting:
+        elif isUpdatesTesting and isEverything:
             # updates-testing-
             if isDebug:
                 prefix = u'updates-testing-debug-f%s' % version

--- a/mirrormanager2/lib/repomap.py
+++ b/mirrormanager2/lib/repomap.py
@@ -27,7 +27,6 @@ def repo_prefix(path, category, ver):
     # assign shortnames to repositories like yum default mirrorlists expects
     isDebug = u'debug' in path
     isRawhide = u'rawhide' in path
-    isBikeshed = u'bikeshed' in path
     isDevelopment = is_development(path) is not None
     isSource = u'source' in path or u'SRPMS' in path
     isUpdatesTesting = u'updates/testing' in path
@@ -40,7 +39,7 @@ def repo_prefix(path, category, ver):
     isEverything = u'Everything' in path
     isFedora = u'Fedora' in path
     isServer = u'Server' in path
-    isModular = u'modular' in path
+    isModular = u'Modular' in path
 
 
     isEpel = (category.name == u'Fedora EPEL')
@@ -80,8 +79,8 @@ def repo_prefix(path, category, ver):
                 prefix = u'epel-%s' % version
 
     elif isFedoraLinux or isFedoraSecondary or isFedoraArchive:
-        if isReleases or isDevelopment or isModular:
-            if isEverything and not isModular:
+        if isReleases or isDevelopment:
+            if isEverything:
                 if isRawhide:
                     # rawhide
                     if isDebug:
@@ -97,7 +96,7 @@ def repo_prefix(path, category, ver):
                     prefix = u'fedora-source-%s' % version
                 else:
                     prefix=u'fedora-%s' % version
-            elif isFedora and not isModular:
+            elif isFedora:
                 if isDebug or isSource:
                     # ignore releases/$version/Fedora/$arch/debug/
                     # ignore releases/$version/Fedora/source/SRPMS/
@@ -105,39 +104,54 @@ def repo_prefix(path, category, ver):
                 else:
                     # fedora-install-
                     prefix = u'fedora-install-%s' % version
-            elif isModular and isServer:
-                if isBikeshed:
-                    # Modular Bikeshed
-                    if isDebug:
-                        prefix = u'modular-bikeshed-server-debug'
-                    elif isSource:
-                        prefix = u'modular-bikeshed-server-source'
-                    else:
-                        prefix = u'modular-bikeshed-server'
-                elif isUpdatesReleased:
-                    # Modular Server updates-released-
-                    if isDebug:
-                        prefix = u'modular-server-updates-released-debug-f%s' % version
-                    elif isSource:
-                        prefix = u'modular-server-updates-released-source-f%s' % version
-                    else:
-                        prefix = u'modular-server-updates-released-f%s' % version
-                elif isUpdatesTesting:
-                    # Modular Server updates-testing
-                    if isDebug:
-                        prefix = u'modular-server-updates-testing-debug-f%s' % version
-                    elif isSource:
-                        prefix = u'modular-server-updates-testing-source-f%s' % version
-                    else:
-                        prefix = u'modular-server-updates-testing-f%s' % version
+            elif isUpdatesReleased:
+                # updates-released-
+                if isDebug:
+                    prefix = u'updates-released-debug-f%s' % version
+                elif isSource:
+                    prefix = u'updates-released-source-f%s' % version
                 else:
-                    #Modular Releases
-                    if isDebug:
-                        prefix = u'modular-fedora-server-debug-f%s' % version
-                    elif isSource:
-                        prefix = u'modular-fedora-server-source-f%s' % version
-                    else:
-                        prefix = u'modular-fedora-server-f%s' % version
+                    prefix = u'updates-released-f%s' % version
+            elif isUpdatesTesting:
+                # updates-testing-
+                if isDebug:
+                    prefix = u'updates-testing-debug-f%s' % version
+                elif isSource:
+                    prefix = u'updates-testing-source-f%s' % version
+                else:
+                    prefix = u'updates-testing-f%s' % version
+        elif isModular:
+            if isUpdatesReleased:
+                # updates-released-modular-
+                if isDebug:
+                    prefix = u'updates-released-modular-debug-f%s' % version
+                elif isSource:
+                    prefix = u'updates-released-modular-source-f%s' % version
+                else:
+                    prefix = u'updates-released-modular-f%s' % version
+            elif isUpdatesTesting:
+                # updates-testing-modular-
+                if isDebug:
+                    prefix = u'updates-testing-modular-debug-f%s' % version
+                elif isSource:
+                    prefix = u'updates-testing-modular-source-f%s' % version
+                else:
+                    prefix = u'updates-testing-modular-f%s' % version
+            elif isRawhide:
+                # rawhide-modular
+                if isDebug:
+                    prefix = u'rawhide-modular-debug'
+                elif isSource:
+                    prefix = u'rawhide-modular-source'
+                else:
+                    prefix = u'rawhide-modular'
+            # fedora-modular-
+            elif isDebug:
+                prefix = u'fedora-modular-debug-%s' % version
+            elif isSource:
+                prefix = u'fedora-modular-source-%s' % version
+            else:
+                prefix=u'fedora-modular-%s' % version
 
         elif isAtomic:
             # atomic

--- a/utility/mm2_update-master-directory-list
+++ b/utility/mm2_update-master-directory-list
@@ -604,11 +604,8 @@ def sync_category_directory(
         # which is used to create the repository.
         # This is not the most flexible implementation.
 
-        # Too make it even 'nicer' this list of directories to skip
-        # is not relevant for the 'modular' directory tree.
         skip_dir = [ u'Cloud', u'Workstation', u'Server' ]
-        if ((not any(x in relativeDName for x in skip_dir)) or
-                ('modular' in relativeDName)):
+        if not any(x in relativeDName for x in skip_dir):
             umdl.make_repository(
                 session, D, relativeDName, category, 'repomd.xml')
 


### PR DESCRIPTION
This is based on Dennis' PR #237 to support the new location of the
'modular' content. This moves the original code a bit around to work
correctly. This has been tested in staging and repositories have been
created correctly:

```
         prefix
------------------------
 rawhide-modular
 rawhide-modular
 rawhide-modular
 rawhide-modular-source
 rawhide-modular-debug
 rawhide-modular-debug
 rawhide-modular-debug
```

Additional, now unnecessary, 'modular' handling code has been removed
from umdl.

Signed-off-by: Adrian Reber <adrian@lisas.de>