### PR TITLE
repomap: more modular repository detection logic

### DIFF
--- a/mirrormanager2/lib/repomap.py
+++ b/mirrormanager2/lib/repomap.py
@@ -96,6 +96,14 @@ def repo_prefix(path, category, ver):
                     prefix = u'fedora-source-%s' % version
                 else:
                     prefix=u'fedora-%s' % version
+            elif isModular:
+                # fedora-modular-
+                if isDebug:
+                    prefix = u'fedora-modular-debug-%s' % version
+                elif isSource:
+                    prefix = u'fedora-modular-source-%s' % version
+                else:
+                    prefix=u'fedora-modular-%s' % version
             elif isFedora:
                 if isDebug or isSource:
                     # ignore releases/$version/Fedora/$arch/debug/


### PR DESCRIPTION
The whole repomap logic is much too complicated and this might have
already existing in some previous versions of repomap.py.

This change has already been verified in Fedora's production
MirrorManager instance.

Signed-off-by: Adrian Reber <adrian@lisas.de>