### PR TITLE
crawler: Correctly calculate the remaining time

### DIFF
--- a/utility/mm2_crawler
+++ b/utility/mm2_crawler
@@ -891,19 +891,19 @@ def try_per_category(
     timeout_check()
 
     # Get remaining time this crawl thread has
-    delta = time.time() - threadlocal.starttime
+    remaining = (timeout * 60) - (time.time() - threadlocal.starttime)
     # Give the rsync process 90% of the remaining time to finish
     # the listing of the available files. 90% could already be too
     # much as updating the status of all scanned directories in the
     # database usually takes quite some time. But there are more
     # timeout checks all over the crawler code to make sure we are
     # not over the timeout.
-    timeout = int(delta * 0.9)
+    local_timeout = int(remaining * 0.9)
 
     rsync_start_time = datetime.datetime.utcnow()
     params = config.get('CRAWLER_RSYNC_PARAMETERS', '--no-motd')
     try:
-        result, listing = run_rsync(url, params, logger, timeout)
+        result, listing = run_rsync(url, params, logger, local_timeout)
     except:
         logger.exception('Failed to run rsync.', exc_info = True)
         return False


### PR DESCRIPTION
The calculation for the rsync timeout was completely wrong. Instead of
calculating the remaining time for the current crawler thread the time
the thread was running was calculated. Which was most of the time 1
second for the first crawled category. This lead to rsync being aborted
after 1 second and the crawler switched to http(s).

With this the remaining time of the crawler thread is now calculated
correctly.

Signed-off-by: Adrian Reber <adrian@lisas.de>