### PR TITLE
crawler: correctly handle keep-alive for HTTPS

### DIFF
--- a/utility/mm2_crawler
+++ b/utility/mm2_crawler
@@ -617,18 +617,24 @@ def check_head(hoststate, url, filedata, recursion, readable, retry=0):
         reqpath += "?%s" % query
     if len(fragment) > 0:
         reqpath += "#%s" % fragment
-    conn.request('HEAD', reqpath,
-                 headers={'Connection':'Keep-Alive',
-                          'Pragma':'no-cache',
-                          'User-Agent':'mirrormanager-crawler/0.1 (+https://github.com/fedora-infra/mirrormanager2/)'})
 
     r = None
     try:
+        conn.request('HEAD', reqpath,
+                     headers={
+                         'Connection': 'Keep-Alive',
+                         'Pragma': 'no-cache',
+                         'User-Agent': 'mirrormanager-crawler/0.1 (+https://'
+                         'github.com/fedora-infra/mirrormanager2/)'})
         r = conn.getresponse()
         status = r.status
     except:
         if retry == 0:
-            # retry once
+            # If the above attempt to connect to the mirror fails, the crawler
+            # will retry once. One possible reason for a connection failure is
+            # that the connection, which is kept open to leverage keep-alive,
+            # has been closed by the remote end. Therefore we are closing
+            # the connection and are restarting the whole operation.
             hoststate.close_http(url)
             return check_head(
                 hoststate, url, filedata, recursion, readable, retry=1)


### PR DESCRIPTION
PR #240 added support to actually scan HTTPS URLs with HTTPS instead of
always using HTTP for HTTPS (really!). The changes from PR #240, however,
let to errors in the keep-alive handling of MirrorManager.

MirrorManager tries to keep connections open if the remote side supports
keep-alive and reuses that connection on subsequent requests.
MirrorManager, however, does not actively track if the keep-alive
connection has been closed by the remote side. If a request fails
MirrorManager does single retry before returning a failure.

For HTTP connections the try/except block seems to be different than for
HTTPS connections.

This adds the code which fails during remotely closed keep-alive
HTTPS connections to the try/except block which seemed to be enough for
HTTP connections.

See: https://pagure.io/fedora-infrastructure/issue/6778

Thanks to Fabrice Bellet for providing an easy reproducer to actually
understand what was happening here.

Signed-off-by: Adrian Reber <adrian@lisas.de>