### PR TITLE
rpmmd: switch from yum.repoMDObject pyrpmmd

### DIFF
--- a/mirrormanager2/lib/umdl.py
+++ b/mirrormanager2/lib/umdl.py
@@ -28,7 +28,7 @@ import optparse
 import os
 import stat
 import sys
-import yum.repoMDObject
+import rpmmd.repoMDObject
 import datetime
 import time
 import hashlib
@@ -284,7 +284,7 @@ def make_repo_file_details(session, config, relativeDName, D, category, target):
     sha512 = hashlib.sha512(contents).hexdigest()
 
     if target == 'repomd.xml':
-        yumrepo = yum.repoMDObject.RepoMD('repoid', absolutepath)
+        yumrepo = rpmmd.repoMDObject.RepoMD('repoid', absolutepath)
         if 'timestamp' not in yumrepo.__dict__:
             set_repomd_timestamp(yumrepo)
         timestamp = yumrepo.timestamp

--- a/utility/mirrormanager2.spec
+++ b/utility/mirrormanager2.spec
@@ -44,7 +44,7 @@ BuildRequires:  %{py2_prefix}-fedmsg-core
 BuildRequires:  %{py2_prefix}-mock
 BuildRequires:  %{py2_prefix}-blinker
 BuildRequires:  rsync
-BuildRequires:  yum
+BuildRequires:  %{py2_prefix}-pyrpmmd
 
 %if 0%{?rhel} && 0%{?rhel} <= 7
 BuildRequires:  python2-rpm-macros
@@ -89,6 +89,7 @@ Requires:  %{name}-filesystem = %{version}-%{release}
 Requires:  %{py2_prefix}-IPy
 Requires:  %{py2_prefix}-dns
 Requires:  %{py2_prefix}-sqlalchemy >= 0.7
+Requires:  %{py2_prefix}-pyrpmmd
 
 %description lib
 Library to interact with MirrorManager's database

--- a/utility/mm2_umdl2
+++ b/utility/mm2_umdl2
@@ -23,12 +23,12 @@ directory (/pub/fedora/linux/updates/....)
 
 import glob
 import logging
+import logging.handlers
 import re
 import optparse
 import os
 import stat
 import sys
-import yum.repoMDObject
 import datetime
 import time
 import hashlib

--- a/utility/mm2_update-master-directory-list
+++ b/utility/mm2_update-master-directory-list
@@ -23,12 +23,13 @@ directory (/pub/fedora/linux/updates/....)
 
 import glob
 import logging
+import logging.handlers
 import re
 import optparse
 import os
 import stat
 import sys
-import yum.repoMDObject
+import rpmmd.repoMDObject
 import datetime
 import time
 import hashlib
@@ -256,7 +257,7 @@ def make_repo_file_details(session, diskpath, relativeDName, D, category, target
     sha512 = hashlib.sha512(contents).hexdigest()
 
     if target == 'repomd.xml':
-        yumrepo = yum.repoMDObject.RepoMD('repoid', absolutepath)
+        yumrepo = rpmmd.repoMDObject.RepoMD('repoid', absolutepath)
         if 'timestamp' not in yumrepo.__dict__:
             umdl.set_repomd_timestamp(yumrepo)
         timestamp = yumrepo.timestamp

--- a/utility/mm2_update-single-file-detail
+++ b/utility/mm2_update-single-file-detail
@@ -16,7 +16,7 @@ import optparse
 import os
 import sys
 
-import yum.repoMDObject
+import rpmmd.repoMDObject
 
 sys.path.insert(0, os.path.join(os.path.dirname(
     os.path.abspath(__file__)), '..'))
@@ -140,7 +140,7 @@ def main():
         target = options.filename.split('/')[-1]
 
         if target == 'repomd.xml':
-            yumrepo = yum.repoMDObject.RepoMD('repoid', absolutepath)
+            yumrepo = rpmmd.repoMDObject.RepoMD('repoid', absolutepath)
             if 'timestamp' not in yumrepo.__dict__:
                 set_repomd_timestamp(yumrepo)
             timestamp = yumrepo.timestamp


### PR DESCRIPTION
With the coming deprecation of yum in Fedora this changes MirrorManager
to use rpmmd instead of yum to read the repomd.xml files.

Fixes: #251

Signed-off-by: Adrian Reber <adrian@lisas.de>