### PR TITLE
crawler: correctly auto-disable mirrors

### DIFF
--- a/utility/mm2_crawler
+++ b/utility/mm2_crawler
@@ -1288,8 +1288,8 @@ def per_host(session, host, options, config):
 
     if not host_categories_to_scan:
         # If the host has no categories do not auto-disable it.
-        # Just skip the host
-        return 0
+        # Just skip the host. rc == 12 do not reset auto-disable
+        return 12
 
     for hc in host_categories_to_scan:
         timeout_check()
@@ -1545,6 +1545,11 @@ def worker(options, config, host_id):
                              "Canary mode failed for all categories. "
                              "Marking host as not up to date.")
             hosts_failed += 1
+        elif rc == 12:
+            # rc == 12: no category to crawl found. This is to make sure,
+            # that host.crawl_failures is not reset to zero for crawling
+            # non existing categories on this host
+            logger.info("No categories to crawl on host %r" % host)
         else:
             # Resetting as this only counts consecutive crawl failures
             host.crawl_failures = 0
@@ -1555,7 +1560,10 @@ def worker(options, config, host_id):
         # required to crawl the complete host so that it does not help
         # to remember it.
         if not (options.repodata or options.canary):
-            host.last_crawl_duration = last_crawl_duration
+            if rc != 12:
+                # rc == 12: no category to crawl found. No need to
+                # update the crawl duration.
+                host.last_crawl_duration = last_crawl_duration
 
         session.commit()
     except TimeoutException:


### PR DESCRIPTION
When using the crawler to scan each category separately a non-existing
category resets the failure counter to 0. This way almost no mirror will
ever be auto-disabled (except broken mirrors having all categories configured).

Signed-off-by: Adrian Reber <adrian@lisas.de>