### PR TITLE
Use protobuf instead of pickle for backend - mirrorlist data exchange

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -68,6 +68,11 @@ Next, install your dependencies::
 
     (my-MirrorMan-env)$ pip install -r requirements.txt
 
+Now the protobuf deinition needs to be compiled to Python::
+
+    (my-MirrorMan-env)$ protoc --python_out=mirrorlist mirrormanager.proto
+    (my-MirrorMan-env)$ protoc --python_out=mirrormanager2/lib mirrormanager.proto
+
 You should then create your own sqlite database for your development instance of
 mirrormanager2::
 

--- a/mirrorlist/test/server_tester.py
+++ b/mirrorlist/test/server_tester.py
@@ -4,7 +4,6 @@
 #  by Matt Domsch <Matt_Domsch@dell.com>
 # Licensed under the MIT/X11 license
 
-from __future__ import print_function
 import socket, os
 try:
     import cPickle as pickle
@@ -31,26 +30,26 @@ def do_mirrorlist(d):
     connectTime = (end - start)
     p = pickle.dumps(d)
     size = len(p)
-    #print "writing size %s to server" % size
-    s.sendall(str(size).zfill(10))
+    #print("writing size %s to server" % size)
+    s.sendall(str(size).encode().zfill(10))
 
     # write the pickle
-    #print "writing the pickle"
+    #print("writing the pickle")
     s.sendall(p)
     s.shutdown(socket.SHUT_WR)
     del p
 
-    #print "reading result pickle size back"
+    #print("reading result pickle size back")
     readlen = 0
-    resultsize = ''
+    resultsize = b''
     while readlen < 10:
         resultsize += s.recv(10 - readlen)
         readlen = len(resultsize)
     resultsize = int(resultsize)
 
-    #print "reading %s bytes of the results list" % resultsize
+    #print("reading %s bytes of the results list" % resultsize)
     readlen = 0
-    p = ''
+    p = b''
     while readlen < resultsize:
         p += s.recv(resultsize - readlen)
         readlen = len(p)
@@ -68,17 +67,17 @@ import random
 while True:
     client_ip = "%s.%s.%s.%s" % (random.randint(0,255), random.randint(0,255), random.randint(0,255), random.randint(0,255))
 
-    d = {'repo':'fedora-18',
-         'arch':'i386',
+    d = {'repo':'fedora-28',
+         'arch':'x86_64',
          'metalink':False}
 
-    for k, v in d.items():
+    for k, v in list(d.items()):
         try:
-            d[k] = unicode(v, 'utf8', 'replace')
+            d[k] = str(v, 'utf8', 'replace')
         except:
             pass
 
-    client_ip = u"%s.%s.%s.%s" % (random.randint(0,255), random.randint(0,255), random.randint(0,255), random.randint(0,255))
+    client_ip = "%s.%s.%s.%s" % (random.randint(0,255), random.randint(0,255), random.randint(0,255), random.randint(0,255))
     d['client_ip'] = client_ip
 
     start = datetime.datetime.utcnow()

--- a/mirrorlist/weighted_shuffle.py
+++ b/mirrorlist/weighted_shuffle.py
@@ -3,11 +3,13 @@
 # Licensed under the MIT/X11 license
 
 from __future__ import print_function
+from functools import total_ordering
 
 import random
 import bisect
 
 
+@total_ordering
 class WeightedListItem:
     def __init__(self, weight, data, start=0):
         self.data = data
@@ -22,10 +24,18 @@ class WeightedListItem:
     def __contains__(self, val):
         return (val >= self.start and val < (self.start + self.weight))
 
-    def __cmp__(self, other):
+    def __eq__(self, other):
         if other.start in self:
-            return 0
-        return cmp(self.start, other.start)
+            return false
+        return (self.start == other.start)
+
+    def __ne__(self, other):
+        return not (self.start == other.start)
+
+    def __lt__(self, other):
+        if other.start in self:
+            return False
+        return ((self.start, self.weight) < (other.start, other.weight))
 
     def __repr__(self):
         return "(%s, %s)" % (self.start, self.weight)

--- a/mirrormanager.proto
+++ b/mirrormanager.proto
@@ -1,0 +1,115 @@
+syntax = "proto2";
+
+/* Generate python files with:
+   $ protoc --python_out=mirrormanager2/lib mirrormanager.proto
+
+   Unfortunately it is not possible to use Protobuf maps as
+   RHEL7/CentOS7's Protobuf is too old.
+*/
+
+package mirrormanager;
+
+message FileDetailsType {
+	required uint64 TimeStamp = 1;
+	required uint64 Size = 2;
+	optional string SHA1 = 3;
+	optional string MD5 = 4;
+	optional string SHA256 = 5;
+	optional string SHA512 = 6;
+}
+
+message FileDetailsCacheFilesType {
+	/* filename, [{details}] (this is a list) */
+	required string filename = 1;
+	repeated FileDetailsType FileDetails = 2;
+}
+
+message FileDetailsCacheDirectoryType {
+	required string directory = 1;
+	repeated FileDetailsCacheFilesType FileDetailsCacheFiles = 2;
+}
+
+message MirrorListCacheType {
+	/* directoryname */
+	required string directory = 1;
+	/* 'global': set() */
+	repeated int64 Global = 2;
+	/* subpath */
+	optional string Subpath = 3;
+	/* country, set(hostid) */
+	repeated StringRepeatedIntMap ByCountry = 4;
+	/* country, set(hostid) */
+	repeated StringRepeatedIntMap ByCountryInternet2 = 5;
+	/* hostid, [hcurl] */
+	repeated IntRepeatedIntMap ByHostId = 6;
+	optional bool OrderedMirrorList = 7;
+}
+
+message StringStringMap {
+	required string key = 1;
+	required string value = 2;
+}
+
+message StringRepeatedIntMap {
+	required string key = 1;
+	repeated int64 value = 2;
+}
+
+message IntRepeatedStringMap {
+	required int64 key = 1;
+	repeated string value = 2;
+}
+
+message IntStringMap {
+	required int64 key = 1;
+	required string value = 2;
+}
+
+message IntIntMap {
+	required int64 key = 1;
+	required int64 value = 2;
+}
+
+message IntRepeatedIntMap {
+	required int64 key = 1;
+	repeated int64 value = 2;
+}
+
+message StringBoolMap {
+	required string key = 1;
+	required bool value = 2;
+}
+
+message MirrorList {
+	required uint64 Time = 1;
+	/* IP, country */
+	repeated StringStringMap NetblockCountryCache = 2;
+	/* location.name, [host.id] */
+	repeated StringRepeatedIntMap LocationCache = 3;
+	/* hcurl.id, hcurl.url */
+	repeated IntStringMap HCUrlCache = 4;
+	/* directoryname, {filename}[{details}] */
+	repeated FileDetailsCacheDirectoryType FileDetailsCache = 5;
+	/* r.prefix, bool */
+	repeated StringBoolMap DisabledRepositoryCache = 6;
+	/* c.country, c.continent */
+	repeated StringStringMap CountryContinentRedirectCache = 7;
+	/* r.from_repo, r.to_repo */
+	repeated StringStringMap RepositoryRedirectCache = 8;
+	/* repo.prefix+repo.arch.name, directoryname */
+	repeated StringStringMap RepoArchToDirectoryName = 9;
+	/* asn, [host.id] */
+	repeated IntRepeatedIntMap HostAsnCache = 10;
+	/* host.id, host.max_connections */
+	repeated IntIntMap HostMaxConnectionCache = 11;
+	/* host.id, host.country */
+	repeated IntStringMap HostCountryCache = 12;
+	/* host.id, host.bandwidth_int */
+	repeated IntIntMap HostBandwidthCache = 13;
+	/* host.id, [list(host.countries_allowed)] */
+	repeated IntRepeatedStringMap HostCountryAllowedCache = 14;
+	/* IP, [host.id] */
+	repeated StringRepeatedIntMap HostNetblockCache = 15;
+	/* directoryname, * */
+	repeated MirrorListCacheType MirrorListCache = 16;
+}

--- a/mirrormanager2/lib/mirrorlist.py
+++ b/mirrormanager2/lib/mirrorlist.py
@@ -42,17 +42,17 @@ import mirrormanager2.lib.mirrormanager_pb2 as mm_pb2
 
 global_caches = dict(
     # key is directoryname
-    mirrorlist_cache = {},
+    mirrorlist_cache={},
     # key is strings in tuple (repo.prefix, arch)
-    repo_arch_to_directoryname = {},
+    repo_arch_to_directoryname={},
     # key is an IPy.IP structure, value is list of host ids
-    host_netblock_cache = {},
+    host_netblock_cache={},
     # key is hostid, value is list of countries to allow
-    host_country_allowed_cache = {},
-    host_country_cache = {},
-    host_bandwidth_cache = {},
-    host_asn_cache = {},
-    )
+    host_country_allowed_cache={},
+    host_country_cache={},
+    host_bandwidth_cache={},
+    host_asn_cache={},
+)
 
 
 def parent_dir(path):
@@ -109,11 +109,13 @@ def populate_directory_cache(session):
             if r.directory and r.version and r.arch:
                 append_value_to_cache(cache, r.directory.id, r)
         return cache
+
     def setup_version_ordered_mirrorlist_cache(session):
         cache = {}
         for v in mirrormanager2.lib.get_versions(session):
             cache[v.id] = v.ordered_mirrorlist
         return cache
+
     def setup_category_topdir_cache(session):
         cache = {}
         for c in mirrormanager2.lib.get_categories(session):
@@ -198,8 +200,8 @@ def populate_directory_cache(session):
 
 
 def name_to_ips(name):
-    result=[]
-    recordtypes=('A', 'AAAA')
+    result = []
+    recordtypes = ('A', 'AAAA')
     for r in recordtypes:
         try:
             records = dns.resolver.query(name, r)
@@ -246,8 +248,10 @@ def populate_host_max_connections_cache(cache, host):
 def populate_host_bandwidth_cache(cache, host):
     try:
         i = int(host.bandwidth_int)
-        if i < 1: i = 1
-        elif i > 100000: i = 100000 # max bandwidth 100Gb
+        if i < 1:
+            i = 1
+        elif i > 100000:
+            i = 100000  # max bandwidth 100Gb
         cache[host.id] = i
     except:
         cache[host.id] = 1
@@ -396,7 +400,8 @@ def dump_caches(session, filename="", protobuf_file=""):
         'host_bandwidth_cache': global_caches['host_bandwidth_cache'],
         'host_country_cache': global_caches['host_country_cache'],
         'host_max_connections_cache': global_caches['host_max_connections_cache'],
-        'asn_host_cache': global_caches['host_asn_cache'], # yeah I misnamed this
+        # yeah I misnamed this
+        'asn_host_cache': global_caches['host_asn_cache'],
         'repo_arch_to_directoryname': global_caches['repo_arch_to_directoryname'],
         'repo_redirect_cache': repository_redirect_cache(session),
         'country_continent_redirect_cache': country_continent_redirect_cache(session),
@@ -552,11 +557,11 @@ def dump_caches(session, filename="", protobuf_file=""):
                 if key == 'subpath':
                     mlc.Subpath = data[
                         'mirrorlist_cache'
-                        ][directory][key]
+                    ][directory][key]
                 if key == 'ordered_mirrorlist':
                     mlc.OrderedMirrorList = data[
                         'mirrorlist_cache'
-                        ][directory][key]
+                    ][directory][key]
                 if key == 'byCountry':
                     countries = data['mirrorlist_cache'][directory][key]
                     for country in countries:

--- a/mirrormanager2/lib/mirrorlist.py
+++ b/mirrormanager2/lib/mirrorlist.py
@@ -22,6 +22,7 @@
 from __future__ import print_function
 
 import datetime
+import time
 import os
 import hashlib
 try:
@@ -36,6 +37,7 @@ import pprint
 import dns.resolver
 
 import mirrormanager2.lib
+import mirrormanager2.lib.mirrormanager_pb2 as mm_pb2
 
 
 global_caches = dict(
@@ -330,6 +332,7 @@ def hcurl_cache(session):
 def location_cache(session):
     cache = {}
     for location in mirrormanager2.lib.get_locations(session):
+        # This does not work - location.hosts does not exist
         cache[location.name] = [host.id for host in list(location.hosts)]
     return cache
 
@@ -378,7 +381,14 @@ def populate_all_caches(session):
     populate_directory_cache(session)
 
 
-def dump_caches(session, filename):
+def dump_caches(session, filename="", protobuf_file=""):
+    ''' This function writes the previously collected
+    information (via populate_all_caches()) to a file.
+    The output format can be a Python pickle or Protobuf.
+    The reason to also offer Protobuf is to be independent
+    of Python's pickle format which does not always work
+    with different versions of Python and used libraries.'''
+
     data = {
         'mirrorlist_cache': global_caches['mirrorlist_cache'],
         'host_netblock_cache': global_caches['host_netblock_cache'],
@@ -398,12 +408,192 @@ def dump_caches(session, filename):
         'time': datetime.datetime.utcnow(),
     }
 
-    try:
-        f = open(filename, 'w')
-        pickle.dump(data, f)
-        f.close()
-        #print 'Pickle generated at %s' % filename
-    except Exception as err:
-        print('Error generating the pickle (%s): %s' % (
-            filename, err))
-        pass
+    if filename != "":
+        try:
+            f = open(filename, 'wb')
+            pickle.dump(data, f)
+            f.close()
+            # print('Pickle generated at %s' % filename)
+        except Exception as err:
+            print('Error generating the pickle (%s): %s' % (
+                filename, err))
+            pass
+
+    if protobuf_file != "":
+        mirrorlist = mm_pb2.MirrorList()
+        mirrorlist.Time = int(time.mktime(data['time'].timetuple()))
+        for key in data['netblock_country_cache']:
+            item = mm_pb2.StringStringMap()
+            item.key = key.strNormal()
+            item.value = data['netblock_country_cache'][key]
+            n = mirrorlist.NetblockCountryCache.add()
+            n.CopyFrom(item)
+
+        for key in data['location_cache']:
+            item = mm_pb2.StringRepeatedIntMap()
+            item.key = key
+            for value in data['location_cache'][key]:
+                item.value.append(value)
+            n = mirrorlist.LocationCache.add()
+            n.CopyFrom(item)
+
+        for key in data['hcurl_cache']:
+            item = mm_pb2.IntStringMap()
+            item.key = key
+            item.value = data['hcurl_cache'][key]
+            n = mirrorlist.HCUrlCache.add()
+            n.CopyFrom(item)
+
+        for key in data['asn_host_cache']:
+            item = mm_pb2.IntRepeatedIntMap()
+            item.key = key
+            for value in data['asn_host_cache'][key]:
+                item.value.append(value)
+            n = mirrorlist.HostAsnCache.add()
+            n.CopyFrom(item)
+
+        for directory in data['file_details_cache']:
+            fdcd = mm_pb2.FileDetailsCacheDirectoryType()
+            fdcd.directory = directory
+            for file_name in data['file_details_cache'][directory]:
+                fdcf = mm_pb2.FileDetailsCacheFilesType()
+                fdcf.filename = file_name
+                for d in data['file_details_cache'][directory][file_name]:
+                    fd = mm_pb2.FileDetailsType()
+                    fd.TimeStamp = d['timestamp']
+                    fd.Size = d['size']
+                    if d['sha1']:
+                        fd.SHA1 = d['sha1']
+                    if d['md5']:
+                        fd.MD5 = d['md5']
+                    if d['sha256']:
+                        fd.SHA256 = d['sha256']
+                    if d['sha512']:
+                        fd.SHA512 = d['sha512']
+                    n = fdcf.FileDetails.add()
+                    n.CopyFrom(fd)
+                n = fdcd.FileDetailsCacheFiles.add()
+                n.CopyFrom(fdcf)
+            n = mirrorlist.FileDetailsCache.add()
+            n.CopyFrom(fdcd)
+
+        for key in data['disabled_repositories']:
+            item = mm_pb2.StringBoolMap()
+            item.key = key
+            item.value = data['disabled_repositories'][key]
+            n = mirrorlist.DisabledRepositoryCache.add()
+            n.CopyFrom(item)
+
+        for key in data['country_continent_redirect_cache']:
+            item = mm_pb2.StringStringMap()
+            item.key = key
+            item.value = data['country_continent_redirect_cache'][key]
+            n = mirrorlist.CountryContinentRedirectCache.add()
+            n.CopyFrom(item)
+
+        for key in data['repo_redirect_cache']:
+            item = mm_pb2.StringStringMap()
+            item.key = key
+            item.value = data['repo_redirect_cache'][key]
+            n = mirrorlist.RepositoryRedirectCache.add()
+            n.CopyFrom(item)
+
+        for key in data['repo_arch_to_directoryname']:
+            item = mm_pb2.StringStringMap()
+            item.key = key[0] + '+' + key[1]
+            item.value = data['repo_arch_to_directoryname'][key]
+            n = mirrorlist.RepoArchToDirectoryName.add()
+            n.CopyFrom(item)
+
+        for key in data['host_max_connections_cache']:
+            item = mm_pb2.IntIntMap()
+            item.key = key
+            item.value = data['host_max_connections_cache'][key]
+            n = mirrorlist.HostMaxConnectionCache.add()
+            n.CopyFrom(item)
+
+        for key in data['host_country_cache']:
+            item = mm_pb2.IntStringMap()
+            item.key = key
+            item.value = data['host_country_cache'][key]
+            n = mirrorlist.HostCountryCache.add()
+            n.CopyFrom(item)
+
+        for key in data['host_bandwidth_cache']:
+            item = mm_pb2.IntIntMap()
+            item.key = key
+            item.value = data['host_bandwidth_cache'][key]
+            n = mirrorlist.HostBandwidthCache.add()
+            n.CopyFrom(item)
+
+        for key in data['host_country_allowed_cache']:
+            item = mm_pb2.IntRepeatedStringMap()
+            item.key = key
+            for value in data['host_country_allowed_cache'][key]:
+                item.value.append(value)
+            n = mirrorlist.HostCountryAllowedCache.add()
+            n.CopyFrom(item)
+
+        for key in data['host_netblock_cache']:
+            item = mm_pb2.StringRepeatedIntMap()
+            item.key = key.strNormal()
+            for value in data['host_netblock_cache'][key]:
+                item.value.append(value)
+            n = mirrorlist.HostNetblockCache.add()
+            n.CopyFrom(item)
+
+        for directory in data['mirrorlist_cache']:
+            mlc = mm_pb2.MirrorListCacheType()
+            mlc.directory = directory
+            for key in data['mirrorlist_cache'][directory]:
+                if key == 'global':
+                    for i in data['mirrorlist_cache'][directory][key]:
+                        mlc.Global.append(i)
+                if key == 'subpath':
+                    mlc.Subpath = data[
+                        'mirrorlist_cache'
+                        ][directory][key]
+                if key == 'ordered_mirrorlist':
+                    mlc.OrderedMirrorList = data[
+                        'mirrorlist_cache'
+                        ][directory][key]
+                if key == 'byCountry':
+                    countries = data['mirrorlist_cache'][directory][key]
+                    for country in countries:
+                        item = mm_pb2.StringRepeatedIntMap()
+                        item.key = country
+                        ids = countries[country]
+                        for i in ids:
+                            item.value.append(i)
+                        n = mlc.ByCountry.add()
+                        n.CopyFrom(item)
+                if key == 'byCountryInternet2':
+                    countries = data['mirrorlist_cache'][directory][key]
+                    for country in countries:
+                        item = mm_pb2.StringRepeatedIntMap()
+                        item.key = country
+                        ids = countries[country]
+                        for i in ids:
+                            item.value.append(i)
+                        n = mlc.ByCountryInternet2.add()
+                        n.CopyFrom(item)
+                if key == 'byHostId':
+                    ids = data['mirrorlist_cache'][directory][key]
+                    for id in ids:
+                        item = mm_pb2.IntRepeatedIntMap()
+                        item.key = id
+                        hcurls = ids[id]
+                        for i in hcurls:
+                            item.value.append(i)
+                        n = mlc.ByHostId.add()
+                        n.CopyFrom(item)
+            n = mirrorlist.MirrorListCache.add()
+            n.CopyFrom(mlc)
+
+        try:
+            f = open(protobuf_file, 'wb')
+            f.write(mirrorlist.SerializeToString())
+            f.close()
+        except Exception as err:
+            print('Error writing %s: %s' % (filename, err))
+            pass

--- a/mirrormanager2/lib/mirrorlist.py
+++ b/mirrormanager2/lib/mirrorlist.py
@@ -76,7 +76,7 @@ def shrink(mc):
     for d in mc:
         for subcache in subcaches:
             c = mc[d][subcache]
-            s = hashlib.sha1(pp.pformat(c)).hexdigest()
+            s = hashlib.sha1(pp.pformat(c).encode('utf-8')).hexdigest()
             if s in matches:
                 mc[d][subcache] = matches[s]
             else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ python-openid-cla
 python-openid-teams
 IPy
 dnspython
+protobuf

--- a/requirements_mirrorlist.txt
+++ b/requirements_mirrorlist.txt
@@ -1,5 +1,6 @@
 # List of dependencies for the mirrormanager repolist server
 
 geoip2
+protobuf
 py-radix>0.8
 webob

--- a/runtests.sh
+++ b/runtests.sh
@@ -2,6 +2,9 @@
 
 set -e
 
+protoc --python_out=mirrorlist mirrormanager.proto
+protoc --python_out=mirrormanager2/lib mirrormanager.proto
+
 # Run Python 2 if it's available
 if [ -x /usr/bin/py.test-2.7 ]; then
 	PYTHONPATH=mirrormanager2 py.test-2.7 --cov=mirrormanager2 $*

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -374,8 +374,40 @@ def create_hosts(session):
     )
     session.add(item)
 
+    session.add(item)
+    item = model.Host(
+        name='Another test entry',
+        site_id=3,
+        robot_email=None,
+        admin_active=True,
+        user_active=True,
+        country='HR',
+        bandwidth_int=300,
+        comment='Public mirror',
+        private=False,
+        internet2=False,
+        internet2_clients=False,
+        asn=None,
+        asn_clients=False,
+        max_connections=10,
+    )
+    session.add(item)
+
     session.commit()
 
+
+def create_host_country_allowed(session):
+    item = model.HostCountryAllowed(
+        country='HR',
+        host_id=4,
+    )
+    session.add(item)
+    item = model.HostCountryAllowed(
+        country='US',
+        host_id=4,
+    )
+    session.add(item)
+    session.commit()
 
 def create_hostaclip(session):
     ''' Create some HostAclIp to play with for the tests
@@ -728,6 +760,16 @@ def create_repository(session):
         disabled=False
     )
     session.add(item)
+    item = model.Repository(
+        name='pub/fedora/linux/updates/27/x86_64',
+        prefix='updates-released-f27',
+        category_id=1,
+        version_id=3,
+        arch_id=3,
+        directory_id=5,
+        disabled=False
+    )
+    session.add(item)
 
     session.commit()
 
@@ -848,6 +890,17 @@ def create_directoryexclusivehost(session):
 def create_filedetail(session):
     ''' Create some FileDetail to play with for the tests
     '''
+    item = model.FileDetail(
+        filename='repomd.xml',
+        directory_id=4,
+        timestamp=1351758825,
+        size=2972,
+        sha1='foo_sha1',
+        md5='foo_md5',
+        sha256='foo_sha256',
+        sha512='foo_sha512',
+    )
+    session.add(item)
     item = model.FileDetail(
         filename='repomd.xml',
         directory_id=7,

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -17,10 +17,6 @@ import os
 
 from contextlib import contextmanager
 from flask import appcontext_pushed, g
-
-sys.path.insert(0, os.path.join(os.path.dirname(
-    os.path.abspath(__file__)), '..'))
-
 from mirrormanager2.app import APP, FAS, LOG
 from mirrormanager2.lib import model
 

--- a/tests/setup_test_container.sh
+++ b/tests/setup_test_container.sh
@@ -25,7 +25,7 @@ sudo docker exec `sed -e "s,:,-," <<< ${1}` \
 	else \
 		${PKG} -y install dnf-plugins-core; \
 	fi; \
-	${PKG} -y install rsync rpm-build && \
+	${PKG} -y install rsync rpm-build protobuf-compiler && \
 	cd /tmp/test && \
 	${BUILDDEP} -y utility/mirrormanager2.spec && \
 	${PKG} -y install ${TEST_PKGS}; \

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -24,11 +24,6 @@ import unittest
 import subprocess
 import sys
 import os
-
-
-sys.path.insert(0, os.path.join(os.path.dirname(
-    os.path.abspath(__file__)), '..'))
-
 import mirrormanager2.lib
 from mirrormanager2.lib.sync import run_rsync
 import tests

--- a/tests/test_mdtr.py
+++ b/tests/test_mdtr.py
@@ -13,11 +13,6 @@ import unittest
 import subprocess
 import sys
 import os
-
-
-sys.path.insert(0, os.path.join(os.path.dirname(
-    os.path.abspath(__file__)), '..'))
-
 import mirrormanager2.lib
 import mirrormanager2.lib.model as model
 import tests

--- a/tests/test_mm_lib_model.py
+++ b/tests/test_mm_lib_model.py
@@ -10,10 +10,6 @@ import pkg_resources
 import unittest
 import sys
 import os
-
-sys.path.insert(0, os.path.join(os.path.dirname(
-    os.path.abspath(__file__)), '..'))
-
 import mirrormanager2.lib
 import mirrormanager2.lib.model as model
 import tests

--- a/tests/test_mmlib.py
+++ b/tests/test_mmlib.py
@@ -10,10 +10,6 @@ import pkg_resources
 import unittest
 import sys
 import os
-
-sys.path.insert(0, os.path.join(os.path.dirname(
-    os.path.abspath(__file__)), '..'))
-
 import mirrormanager2.lib
 import mirrormanager2.lib.mirrorlist
 import mirrormanager2.lib.mirrormanager_pb2

--- a/tests/test_mmlib.py
+++ b/tests/test_mmlib.py
@@ -142,7 +142,7 @@ class MMLibtests(tests.Modeltests):
         tests.create_hosts(self.session)
 
         results = mirrormanager2.lib.get_hosts(self.session)
-        self.assertEqual(len(results), 3)
+        self.assertEqual(len(results), 4)
         self.assertEqual(results[0].name, 'mirror.localhost')
         self.assertEqual(results[0].country, 'US')
         self.assertEqual(results[1].name, 'mirror2.localhost')
@@ -689,7 +689,7 @@ class MMLibtests(tests.Modeltests):
         tests.create_repository(self.session)
 
         results = mirrormanager2.lib.get_repositories(self.session)
-        self.assertEqual(len(results), 3)
+        self.assertEqual(len(results), 4)
         self.assertEqual(
             results[0].name, 'pub/fedora/linux/updates/testing/25/x86_64')
         self.assertEqual(results[0].arch.name, 'x86_64')
@@ -777,6 +777,20 @@ class MMLibtests(tests.Modeltests):
         self.assertEqual(results[0].netblock, '127.0.0.0/24')
         self.assertEqual(results[0].country, 'AU')
 
+    def check_results_host(self, results):
+        for result in results:
+            if result.id == 1:
+                self.assertEqual(result.name, 'mirror.localhost')
+            elif result.id == 2:
+                self.assertEqual(result.name, 'mirror2.localhost')
+            elif result.id == 3:
+                self.assertEqual(result.name, 'private.localhost')
+            elif result.id == 4:
+                self.assertEqual(result.name, 'Another test entry')
+            else:
+                self.assertTrue(False)
+
+
     def test_get_mirrors(self):
         """ Test the get_mirrors function of mirrormanager2.lib.
         """
@@ -794,10 +808,8 @@ class MMLibtests(tests.Modeltests):
         tests.create_netblockcountry(self.session)
 
         results = mirrormanager2.lib.get_mirrors(self.session)
-        self.assertEqual(len(results), 3)
-        self.assertEqual(results[0].name, 'mirror2.localhost')
-        self.assertEqual(results[1].name, 'private.localhost')
-        self.assertEqual(results[2].name, 'mirror.localhost')
+        self.assertEqual(len(results), 4)
+        self.check_results_host(results)
 
         results = mirrormanager2.lib.get_mirrors(self.session, private=True)
         self.assertEqual(len(results), 1)
@@ -811,10 +823,8 @@ class MMLibtests(tests.Modeltests):
         self.assertEqual(len(results), 0)
         results = mirrormanager2.lib.get_mirrors(
             self.session, internet2_clients=False)
-        self.assertEqual(len(results), 3)
-        self.assertEqual(results[0].name, 'mirror2.localhost')
-        self.assertEqual(results[1].name, 'private.localhost')
-        self.assertEqual(results[2].name, 'mirror.localhost')
+        self.assertEqual(len(results), 4)
+        self.check_results_host(results)
 
         results = mirrormanager2.lib.get_mirrors(
             self.session, asn_clients=True)
@@ -822,29 +832,24 @@ class MMLibtests(tests.Modeltests):
         self.assertEqual(results[0].name, 'mirror2.localhost')
         results = mirrormanager2.lib.get_mirrors(
             self.session, asn_clients=False)
-        self.assertEqual(len(results), 2)
-        self.assertEqual(results[0].name, 'private.localhost')
-        self.assertEqual(results[1].name, 'mirror.localhost')
+        self.assertEqual(len(results), 3)
+        self.check_results_host(results)
 
         results = mirrormanager2.lib.get_mirrors(
             self.session, admin_active=False)
         self.assertEqual(len(results), 0)
         results = mirrormanager2.lib.get_mirrors(
             self.session, admin_active=True)
-        self.assertEqual(len(results), 3)
-        self.assertEqual(results[0].name, 'mirror2.localhost')
-        self.assertEqual(results[1].name, 'private.localhost')
-        self.assertEqual(results[2].name, 'mirror.localhost')
+        self.assertEqual(len(results), 4)
+        self.check_results_host(results)
 
         results = mirrormanager2.lib.get_mirrors(
             self.session, user_active=False)
         self.assertEqual(len(results), 0)
         results = mirrormanager2.lib.get_mirrors(
             self.session, user_active=True)
-        self.assertEqual(len(results), 3)
-        self.assertEqual(results[0].name, 'mirror2.localhost')
-        self.assertEqual(results[1].name, 'private.localhost')
-        self.assertEqual(results[2].name, 'mirror.localhost')
+        self.assertEqual(len(results), 4)
+        self.check_results_host(results)
 
         results = mirrormanager2.lib.get_mirrors(
             self.session, host_category_url_private=True)
@@ -859,60 +864,48 @@ class MMLibtests(tests.Modeltests):
         self.assertEqual(len(results), 0)
         results = mirrormanager2.lib.get_mirrors(
             self.session, last_crawl_duration=False)
-        self.assertEqual(len(results), 3)
-        self.assertEqual(results[0].name, 'mirror2.localhost')
-        self.assertEqual(results[1].name, 'private.localhost')
-        self.assertEqual(results[2].name, 'mirror.localhost')
+        self.assertEqual(len(results), 4)
+        self.check_results_host(results)
 
         results = mirrormanager2.lib.get_mirrors(
             self.session, last_crawled=True)
         self.assertEqual(len(results), 0)
         results = mirrormanager2.lib.get_mirrors(
             self.session, last_crawled=False)
-        self.assertEqual(len(results), 3)
-        self.assertEqual(results[0].name, 'mirror2.localhost')
-        self.assertEqual(results[1].name, 'private.localhost')
-        self.assertEqual(results[2].name, 'mirror.localhost')
+        self.assertEqual(len(results), 4)
+        self.check_results_host(results)
 
         results = mirrormanager2.lib.get_mirrors(
             self.session, last_checked_in=True)
         self.assertEqual(len(results), 0)
         results = mirrormanager2.lib.get_mirrors(
             self.session, last_checked_in=False)
-        self.assertEqual(len(results), 3)
-        self.assertEqual(results[0].name, 'mirror2.localhost')
-        self.assertEqual(results[1].name, 'private.localhost')
-        self.assertEqual(results[2].name, 'mirror.localhost')
+        self.assertEqual(len(results), 4)
+        self.check_results_host(results)
 
         results = mirrormanager2.lib.get_mirrors(
             self.session, site_private=True)
-        self.assertEqual(len(results), 0)
+        self.assertEqual(len(results), 1)
         results = mirrormanager2.lib.get_mirrors(
             self.session, site_private=False)
         self.assertEqual(len(results), 3)
-        self.assertEqual(results[0].name, 'mirror2.localhost')
-        self.assertEqual(results[1].name, 'private.localhost')
-        self.assertEqual(results[2].name, 'mirror.localhost')
+        self.check_results_host(results)
 
         results = mirrormanager2.lib.get_mirrors(
             self.session, site_user_active=False)
         self.assertEqual(len(results), 0)
         results = mirrormanager2.lib.get_mirrors(
             self.session, site_user_active=True)
-        self.assertEqual(len(results), 3)
-        self.assertEqual(results[0].name, 'mirror2.localhost')
-        self.assertEqual(results[1].name, 'private.localhost')
-        self.assertEqual(results[2].name, 'mirror.localhost')
+        self.assertEqual(len(results), 4)
+        self.check_results_host(results)
 
         results = mirrormanager2.lib.get_mirrors(
             self.session, site_admin_active=False)
         self.assertEqual(len(results), 0)
         results = mirrormanager2.lib.get_mirrors(
             self.session, site_admin_active=True)
-        self.assertEqual(len(results), 3)
-        self.assertEqual(results[0].name, 'mirror2.localhost')
-        self.assertEqual(results[1].name, 'private.localhost')
-        self.assertEqual(results[2].name, 'mirror.localhost')
+        self.assertEqual(len(results), 4)
+        self.check_results_host(results)
 
         results = mirrormanager2.lib.get_mirrors(
             self.session, up2date=True)
@@ -925,7 +918,7 @@ class MMLibtests(tests.Modeltests):
             self.session, version_id=1)
         self.assertEqual(len(results), 0)
         results = mirrormanager2.lib.get_mirrors(
-            self.session, version_id=3)
+            self.session, version_id=4)
 
         tests.create_version(self.session)
         tests.create_repository(self.session)
@@ -938,8 +931,7 @@ class MMLibtests(tests.Modeltests):
         results = mirrormanager2.lib.get_mirrors(
             self.session, version_id=3)
         self.assertEqual(len(results), 2)
-        self.assertEqual(results[0].name, 'mirror2.localhost')
-        self.assertEqual(results[1].name, 'mirror.localhost')
+        self.check_results_host(results)
 
         results = mirrormanager2.lib.get_mirrors(
             self.session, arch_id=1)
@@ -947,8 +939,7 @@ class MMLibtests(tests.Modeltests):
         results = mirrormanager2.lib.get_mirrors(
             self.session, arch_id=3)
         self.assertEqual(len(results), 2)
-        self.assertEqual(results[0].name, 'mirror2.localhost')
-        self.assertEqual(results[1].name, 'mirror.localhost')
+        self.check_results_host(results)
 
     def test_get_user_sites(self):
         """ Test the get_user_sites function of mirrormanager2.lib.

--- a/tests/test_mta.py
+++ b/tests/test_mta.py
@@ -119,7 +119,7 @@ class MTATest(tests.Modeltests):
         # Before the script
 
         results = mirrormanager2.lib.get_repositories(self.session)
-        self.assertEqual(len(results), 3)
+        self.assertEqual(len(results), 4)
         self.assertEqual(results[0].prefix, 'updates-testing-f25')
         self.assertEqual(
             results[0].directory.name,
@@ -194,7 +194,7 @@ class MTATest(tests.Modeltests):
         self.assertEqual(stderr, '')
 
         results = mirrormanager2.lib.get_repositories(self.session)
-        self.assertEqual(len(results), 3)
+        self.assertEqual(len(results), 4)
         self.assertEqual(results[0].prefix, 'updates-testing-f25')
         self.assertEqual(
             results[0].directory.name,

--- a/tests/test_mta.py
+++ b/tests/test_mta.py
@@ -11,11 +11,6 @@ import unittest
 import subprocess
 import sys
 import os
-
-
-sys.path.insert(0, os.path.join(os.path.dirname(
-    os.path.abspath(__file__)), '..'))
-
 import mirrormanager2.lib
 import mirrormanager2.lib.model as model
 import tests

--- a/tests/test_ui_admin.py
+++ b/tests/test_ui_admin.py
@@ -12,12 +12,7 @@ import unittest
 import sys
 import os
 import re
-
 from mock import patch
-
-sys.path.insert(0, os.path.join(os.path.dirname(
-    os.path.abspath(__file__)), '..'))
-
 import mirrormanager2.admin
 import mirrormanager2.app
 from mirrormanager2.lib import model

--- a/tests/test_ui_admin.py
+++ b/tests/test_ui_admin.py
@@ -342,7 +342,7 @@ class FlaskUiAdminTest(tests.Modeltests):
                 '<a href="/admin/host(view)?/\?sort=[0-9]" '
                 'title="Sort by Name">Name</a>', data))
             self.assertTrue(
-                '<a href="javascript:void(0)">List (3)</a>' in data)
+                '<a href="javascript:void(0)">List (4)</a>' in data)
 
     @patch('mirrormanager2.app.is_mirrormanager_admin')
     def test_admin_hostaclipview(self, login_func):
@@ -663,7 +663,7 @@ class FlaskUiAdminTest(tests.Modeltests):
                 '<a href="/admin/repository(view)?/\?sort=[0-4]" '
                 'title="Sort by Name">Name</a>', data))
             self.assertTrue(
-                '<a href="javascript:void(0)">List (3)</a>' in data)
+                '<a href="javascript:void(0)">List (4)</a>' in data)
 
     @patch('mirrormanager2.app.is_mirrormanager_admin')
     def test_admin_repositoryredirectview(self, login_func):

--- a/tests/test_ui_app.py
+++ b/tests/test_ui_app.py
@@ -11,12 +11,7 @@ import json
 import unittest
 import sys
 import os
-
 from mock import patch
-
-sys.path.insert(0, os.path.join(os.path.dirname(
-    os.path.abspath(__file__)), '..'))
-
 import mirrormanager2.admin
 import mirrormanager2.app
 from mirrormanager2.lib import model

--- a/tests/test_umdl.py
+++ b/tests/test_umdl.py
@@ -8,16 +8,10 @@ from __future__ import print_function
 
 __requires__ = ['SQLAlchemy >= 0.7']
 import pkg_resources
-
 import unittest
 import subprocess
 import sys
 import os
-
-
-sys.path.insert(0, os.path.join(os.path.dirname(
-    os.path.abspath(__file__)), '..'))
-
 import mirrormanager2.lib
 import tests
 

--- a/utility/mirrormanager2.spec
+++ b/utility/mirrormanager2.spec
@@ -40,6 +40,7 @@ BuildRequires:  python%{python_pkgversion}-fedora-flask >= 0.3.33
 BuildRequires:  python%{python_pkgversion}-setuptools
 BuildRequires:  python%{python_pkgversion}-psutil
 BuildRequires:  python%{python_pkgversion}-alembic
+BuildRequires:  protobuf-compiler
 # Mirrorlist
 BuildRequires:  python%{python_pkgversion}-geoip2
 BuildRequires:  python%{python_pkgversion}-webob
@@ -55,8 +56,10 @@ BuildRequires:  python%{python_pkgversion}-pyrpmmd
 %if 0%{?rhel} && 0%{?rhel} <= 7
 BuildRequires:  python2-rpm-macros
 BuildRequires:  py-radix
+BuildRequires:  protobuf-python
 Requires:  mod_wsgi
 %else
+BuildRequires:  python%{python_pkgversion}-protobuf
 BuildRequires:  python%{python_pkgversion}-py-radix
 Requires:  python%{python3_pkgversion}-mod_wsgi
 %endif
@@ -96,6 +99,11 @@ Requires:  python%{python_pkgversion}-IPy
 Requires:  python%{python_pkgversion}-dns
 Requires:  python%{python_pkgversion}-sqlalchemy >= 0.7
 Requires:  python%{python_pkgversion}-pyrpmmd
+%if 0%{?rhel} && 0%{?rhel} <= 7
+Requires:  protobuf-python
+%else
+Requires:  python%{python_pkgversion}-protobuf
+%endif
 
 %description lib
 Library to interact with MirrorManager's database
@@ -114,9 +122,11 @@ Requires:  httpd
 %if 0%{?rhel} && 0%{?rhel} <= 7
 Requires:  py-radix
 Requires:  mod_wsgi
+Requires:  protobuf-python
 %else
 Requires:  python%{python_pkgversion}-py-radix
 Requires:  python%{python_pkgversion}-mod_wsgi
+Requires:  python%{python_pkgversion}-protobuf
 %endif
 Requires:  systemd
 Requires(pre):  shadow-utils
@@ -206,6 +216,9 @@ Base directories used by multiple subpackages
 
 
 %build
+# Recreating protobuf output
+protoc --python_out=mirrorlist mirrormanager.proto
+protoc --python_out=mirrormanager2/lib mirrormanager.proto
 %py_build
 
 
@@ -263,6 +276,8 @@ install -m 644 mirrorlist/mirrorlist_server.py \
     $RPM_BUILD_ROOT/%{_datadir}/mirrormanager2/mirrorlist_server.py
 install -m 644 mirrorlist/weighted_shuffle.py \
     $RPM_BUILD_ROOT/%{_datadir}/mirrormanager2/weighted_shuffle.py
+install -m 644 mirrorlist/mirrormanager_pb2.py \
+    $RPM_BUILD_ROOT/%{_datadir}/mirrormanager2/mirrormanager_pb2.py
 
 # Install the createdb script
 install -m 644 createdb.py \

--- a/utility/mm2_crawler
+++ b/utility/mm2_crawler
@@ -1288,8 +1288,8 @@ def per_host(session, host, options, config):
 
     if not host_categories_to_scan:
         # If the host has no categories do not auto-disable it.
-        # Just skip the host
-        return 0
+        # Just skip the host. rc == 12 do not reset auto-disable
+        return 12
 
     for hc in host_categories_to_scan:
         timeout_check()
@@ -1545,6 +1545,11 @@ def worker(options, config, host_id):
                              "Canary mode failed for all categories. "
                              "Marking host as not up to date.")
             hosts_failed += 1
+        elif rc == 12:
+            # rc == 12: no category to crawl found. This is to make sure,
+            # that host.crawl_failures is not reset to zero for crawling
+            # non existing categories on this host
+            logger.info("No categories to crawl on host %r" % host)
         else:
             # Resetting as this only counts consecutive crawl failures
             host.crawl_failures = 0


### PR DESCRIPTION
This is an experiment to see if protbuf is better suited for data transfer from the backend to the mirrorlist server.