### PR TITLE
Let mirrors specify multiple countries

### DIFF
--- a/mirrormanager2/lib/mirrorlist.py
+++ b/mirrormanager2/lib/mirrorlist.py
@@ -171,24 +171,27 @@ def populate_directory_cache(session):
                 category_topdir_cache[category_id]:]
             del repos
 
+        countries = []
         if country is not None:
             country = country.upper()
+            countries = country.split(u',')
 
         if not siteprivate and not hostprivate:
             add_host_to_set(cache[directoryname]['global'], hostid)
 
-            if country is not None:
+            for country in countries:
                 if country not in cache[directoryname]['byCountry']:
                     cache[directoryname]['byCountry'][country] = set()
                 add_host_to_set(
                     cache[directoryname]['byCountry'][country], hostid)
 
-        if country is not None and i2 and \
+        for country in countries:
+            if i2 and \
                 ((not siteprivate and not hostprivate) or i2_clients):
-            if country not in cache[directoryname]['byCountryInternet2']:
-                cache[directoryname]['byCountryInternet2'][country] = set()
-            add_host_to_set(
-                cache[directoryname]['byCountryInternet2'][country], hostid)
+                if country not in cache[directoryname]['byCountryInternet2']:
+                    cache[directoryname]['byCountryInternet2'][country] = set()
+                add_host_to_set(
+                    cache[directoryname]['byCountryInternet2'][country], hostid)
 
         append_value_to_cache(cache[directoryname]['byHostId'], hostid, hcurl)
 
@@ -254,7 +257,11 @@ def populate_host_bandwidth_cache(cache, host):
 
 
 def populate_host_country_cache(cache, host):
-    cache[host.id] = host.country
+    if u',' in host.country:
+        country = host.country.split(u',')[0]
+    else:
+        country = host.country
+    cache[host.id] = country.strip()
     return cache
 
 


### PR DESCRIPTION
https://github.com/fedora-infra/mirrormanager2/issues/267
requests the ability for a mirror (really, a globally load balanced
set of mirrors behind a single DNS name) to be able to specify the
countries of their actual mirrors.

This patch lets Host.country be a comma-separated list of countries.