### PR TITLE
Fix report_mirror with python3

### DIFF
--- a/client/report_mirror
+++ b/client/report_mirror
@@ -1,7 +1,9 @@
 #!/usr/bin/env python
 
 from __future__ import print_function
-import os, sys
+import os
+import sys
+import copy
 import json
 try:
     import configparser
@@ -20,12 +22,13 @@ exclude_list = []
 class HostConfig(object):
     """Holder for config info from the configuration file"""
     def __init__(self):
-        self.config = { 'version' : 0,
-                        'global': {},
-                        'site': {},
-                        'host': {},
-                        'stats': {},
-                        }
+        self.config = {
+            'version': 0,
+            'global': {},
+            'site': {},
+            'host': {},
+            'stats': {},
+        }
 
 
 def get_exclude_dir_patterns_from_file(options):
@@ -34,18 +37,18 @@ def get_exclude_dir_patterns_from_file(options):
         f = open(options.exclude_from, 'r')
         for line in f:
             line = line.strip()
-            if line.startswith(u'#'): continue
+            if line.startswith(u'#'):
+                continue
             exclude_list.append(line)
         f.close()
 
 
-import copy
 def exclude_dirs(root, dirs):
     global exclude_list
     copydirs = copy.copy(dirs)
     # iterate over the copy so we can modify the original
     for d in copydirs:
-        #keep trailing /, we know it's a directory
+        # keep trailing /, we know it's a directory
         testdir = os.path.join(root, d, '')
         for pattern in exclude_list:
             if pattern in testdir:
@@ -136,7 +139,7 @@ def parse_section(conf, section, item, required_options,
 
 
 def parse_global(conf, section, item):
-    required_options = [ 'enabled', 'server' ]
+    required_options = ['enabled', 'server']
     if not parse_section(conf, section, item, required_options):
         errorprint(
             'missing required options (server AND enabled) in [%s] section'
@@ -146,13 +149,13 @@ def parse_global(conf, section, item):
 
 
 def parse_site(conf, section, item):
-    required_options = [ 'enabled', 'name', 'password' ]
+    required_options = ['enabled', 'name', 'password']
     return parse_section(conf, section, item, required_options)
 
 
 def parse_host(conf, section, item):
-    required_options = [ 'enabled', 'name' ]
-    optional_options = [ 'user_active' ]
+    required_options = ['enabled', 'name']
+    optional_options = ['user_active']
     return parse_section(
         conf, section, item, required_options,
         optional_options=optional_options)
@@ -168,20 +171,20 @@ def get_stats(conf, section):
             continue
         filenames = parse_value(conf.get(section, name))
         if type(filenames) != list:
-            filenames = [ filenames ]
+            filenames = [filenames]
         for fn in filenames:
             try:
                 f = open(fn, 'r')
                 contents = contents + f.readlines()
                 statsdata[name] = json.dumps(contents, -1)
                 f.close()
-            except:
+            except IOError:
                 pass
     return statsdata
 
 
 def parse_category(conf, section, item, crawl):
-    required_options = [ 'enabled', 'path' ]
+    required_options = ['enabled', 'path']
     if not parse_section(conf, section, item, required_options):
         return False
 
@@ -207,7 +210,7 @@ def config(cfg, item, crawl=True):
                 ('global', parse_global),
                 ('site', parse_site),
                 ('host', parse_host)
-            ]:
+                ]:
             if conf.has_section(section):
                 if not parsefunc(conf, section, item):
                     return False
@@ -218,7 +221,7 @@ def config(cfg, item, crawl=True):
                 sys.exit(1)
 
         for section in conf.sections():
-            if section in [ 'global', 'site', 'host', 'stats']:
+            if section in ['global', 'site', 'host', 'stats']:
                 continue
             parse_category(conf, section, item, crawl)
 
@@ -228,12 +231,13 @@ def config(cfg, item, crawl=True):
 
     return True
 
-options=None
+
+options = None
 
 
 def main():
     from optparse import OptionParser
-    parser = OptionParser(usage= sys.argv[0] + " [options]")
+    parser = OptionParser(usage=sys.argv[0] + " [options]")
     parser.add_option("-c", "--config",
                       dest="config",
                       default='/etc/mirrormanager-client/report_mirror.conf',
@@ -298,7 +302,7 @@ def main():
         sys.exit(1)
 
     if not options.no_send:
-        #   print "Connecting to %s" % item.config['global']['server']
+        #  print("Connecting to %s" % item.config['global']['server'])
         server = xmlrpclib.ServerProxy(item.config['global']['server'])
 
         data = base64.urlsafe_b64encode(bz2.compress(p))

--- a/client/report_mirror
+++ b/client/report_mirror
@@ -28,23 +28,6 @@ class HostConfig(object):
                         }
 
 
-_translation = [chr(_x) for _x in range(256)]
-def _translate(s, altchars):
-    translation = _translation[:]
-    for k, v in altchars.items():
-        translation[ord(k)] = v
-    return s.translate(''.join(translation))
-
-
-def urlsafe_b64encode(s):
-   import binascii
-   altchars = '-_'
-   encoded = binascii.b2a_base64(s)[:-1]
-   if altchars is not None:
-      return _translate(encoded, {'+': altchars[0], '/': altchars[1]})
-   return encoded
-
-
 def get_exclude_dir_patterns_from_file(options):
     global exclude_list
     if options.exclude_from:
@@ -317,11 +300,8 @@ def main():
     if not options.no_send:
         #   print "Connecting to %s" % item.config['global']['server']
         server = xmlrpclib.ServerProxy(item.config['global']['server'])
-        data = None
-        try:
-            data = base64.urlsafe_b64encode(bz2.compress(p))
-        except AttributeError:
-            data = urlsafe_b64encode(bz2.compress(p))
+
+        data = base64.urlsafe_b64encode(bz2.compress(p))
 
         if data is not None:
             try:

--- a/client/report_mirror
+++ b/client/report_mirror
@@ -176,7 +176,7 @@ def get_stats(conf, section):
             try:
                 f = open(fn, 'r')
                 contents = contents + f.readlines()
-                statsdata[name] = json.dumps(contents, -1)
+                statsdata[name] = json.dumps(contents)
                 f.close()
             except IOError:
                 pass
@@ -283,7 +283,7 @@ def main():
         if not config(options.config, item, crawl=True):
             sys.exit(1)
 
-    p = json.dumps(item.config, -1)
+    p = json.dumps(item.config)
 
     if options.debug:
         pp = pprint.PrettyPrinter(indent=4)

--- a/client/report_mirror
+++ b/client/report_mirror
@@ -10,7 +10,10 @@ try:
 except ImportError:
     import ConfigParser as configparser
 import pprint
-import xmlrpclib
+try:
+    import xmlrpclib
+except ImportError:
+    import xmlrpc.client as xmlrpclib
 import base64
 import bz2
 import socket
@@ -305,7 +308,7 @@ def main():
         #  print("Connecting to %s" % item.config['global']['server'])
         server = xmlrpclib.ServerProxy(item.config['global']['server'])
 
-        data = base64.urlsafe_b64encode(bz2.compress(p))
+        data = base64.urlsafe_b64encode(bz2.compress(p.encode())).decode()
 
         if data is not None:
             try:

--- a/mirrormanager2/lib/hostconfig.py
+++ b/mirrormanager2/lib/hostconfig.py
@@ -85,18 +85,27 @@ def validate_config(config):
 def read_host_config(session, config):
     rc, message = validate_config(config)
     if not rc:
-        return (None, message + 'Invalid config file provided, please '
+        return (None, '', message + 'Invalid config file provided, please '
                 'check your report_mirror.conf.')
 
     csite = config['site']
     chost = config['host']
+    chostname = chost['name']
 
     site = mirrormanager2.lib.get_site_by_name(session, csite['name'])
     if not site:
-        return (None, 'Config file site name or password incorrect.\n')
+        return (
+                None,
+                chostname,
+                'Config file site name or password incorrect.\n'
+        )
 
     if csite['password'] != site.password:
-        return (None, 'Config file site name or password incorrect.\n')
+        return (
+                None,
+                chostname,
+                'Config file site name or password incorrect.\n'
+        )
 
     host = None
     for tmp_host in site.hosts:
@@ -105,7 +114,7 @@ def read_host_config(session, config):
             break
 
     if not host:
-        return (None, 'Config file host name for site not found.\n')
+        return (None, chostname, 'Config file host name for site not found.\n')
 
     # handle the optional arguments
     if 'user_active' in config['host']:
@@ -115,4 +124,4 @@ def read_host_config(session, config):
             host.user_active = False
 
     message = mirrormanager2.lib.uploaded_config(session, host, config)
-    return (True, message)
+    return (True, chostname, message)

--- a/mirrormanager2/lib/hostconfig.py
+++ b/mirrormanager2/lib/hostconfig.py
@@ -29,12 +29,13 @@ import logging
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
+
 def validate_config(config):
     message = ''
     if type(config) != dict:
         logging.critical("NON-DICT SUBMITTED: %s" % config)
         message += 'config file is not a dict.\n'\
-        'Please update your copy of report_mirror.\n'
+            'Please update your copy of report_mirror.\n'
         return (False, message)
     if 'version' not in config:
         message += 'config file has no version field.\n'
@@ -66,7 +67,7 @@ def validate_config(config):
     host = config['host']
     for opt in ['name']:
         if opt not in host:
-            message +=  'section [host] missing required option %s.\n' % (
+            message += 'section [host] missing required option %s.\n' % (
                 opt)
             return (False, message)
 

--- a/mirrormanager2/xml_rpc.py
+++ b/mirrormanager2/xml_rpc.py
@@ -46,16 +46,20 @@ XMLRPC.connect(APP, '/xmlrpc')
 
 @XMLRPC.register
 def checkin(pickledata):
+    is_pickle = False
     uncompressed = bz2.decompress(base64.urlsafe_b64decode(pickledata))
     try:
         config = json.loads(uncompressed)
     except ValueError:
         logging.info("Fell back to pickle")
+        is_pickle = True
         config = pickle.loads(uncompressed)
-    r, message = read_host_config(SESSION, config)
+    r, host, message = read_host_config(SESSION, config)
     if r is not None:
-        logging.info("Checkin succesful: %s" % message)
+        logging.info("Checkin for host %s (pickle:%s) succesful: %s" %
+                (host, is_pickle, message))
         return message + 'checked in successful'
     else:
-        logging.error("Error during checkin: %s" % message)
+        logging.error("Error for host %s (pickle:%s) during checkin: %s" %
+                (host, is_pickle, message))
         return message + 'error checking in'


### PR DESCRIPTION
This tries to fix https://bugzilla.redhat.com/show_bug.cgi?id=1707684 which reported that report_mirror does not work. This now works with python2 and python3.

At the same time this adds some debug output to the xmlrpc checkin code. to better see which hosts are using pickle and which are using json.