### PR TITLE
Removes fedmenu from mirrormanager2

### DIFF
--- a/mirrormanager2/templates/fedora/master_noauth.html
+++ b/mirrormanager2/templates/fedora/master_noauth.html
@@ -85,18 +85,6 @@
     <script type="text/javascript" src="https://apps.fedoraproject.org/global/fedora-bootstrap-1.0.2/fedora-bootstrap.js">
     </script>
 
-
-    {% if config['FEDMENU_URL'] %}
-    <script src="{{ config['FEDMENU_URL'] }}/js/fedmenu.js"></script>
-    <script>
-      fedmenu({
-          'url': '{{ config["FEDMENU_DATA_URL"] }}',
-          'mimeType': 'application/javascript',
-          'position': 'bottom-right',
-      });
-    </script>
-    {% endif %}
-
     {% endblock %}
 </body>
 </html>


### PR DESCRIPTION
Fixes #271 "Remove fedmenu from mirrormanager2"

From looking at the revision history, it is my understanding that fedmenu brought in a dependency to jQuery 1.11.2 with it as can be seen in 888245cc76ad5c44f969459b0747acafb3bbfc07.

I wasn't sure I could remove the reference to it since bootstrap takes a dependency on jQuery and I don't know if it takes care of bringing it in itself.