### PR TITLE
Only query database once for mirrorlist export

### DIFF
--- a/mirrormanager2/lib/mirrorlist.py
+++ b/mirrormanager2/lib/mirrorlist.py
@@ -54,6 +54,7 @@ global_caches = dict(
     host_asn_cache={},
 )
 
+data = dict()
 
 def parent_dir(path):
     return os.path.dirname(path)
@@ -381,18 +382,9 @@ def populate_host_caches(session):
 
 
 def populate_all_caches(session):
+    global data
     populate_host_caches(session)
     populate_directory_cache(session)
-
-
-def dump_caches(session, filename="", protobuf_file=""):
-    ''' This function writes the previously collected
-    information (via populate_all_caches()) to a file.
-    The output format can be a Python pickle or Protobuf.
-    The reason to also offer Protobuf is to be independent
-    of Python's pickle format which does not always work
-    with different versions of Python and used libraries.'''
-
     data = {
         'mirrorlist_cache': global_caches['mirrorlist_cache'],
         'host_netblock_cache': global_caches['host_netblock_cache'],
@@ -412,6 +404,15 @@ def dump_caches(session, filename="", protobuf_file=""):
         'netblock_country_cache': netblock_country_cache(session),
         'time': datetime.datetime.utcnow(),
     }
+
+
+def dump_caches(session, filename="", protobuf_file=""):
+    ''' This function writes the previously collected
+    information (via populate_all_caches()) to a file.
+    The output format can be a Python pickle or Protobuf.
+    The reason to also offer Protobuf is to be independent
+    of Python's pickle format which does not always work
+    with different versions of Python and used libraries.'''
 
     if filename != "":
         try:

--- a/utility/mm2_update-mirrorlist-server
+++ b/utility/mm2_update-mirrorlist-server
@@ -29,6 +29,6 @@ rm -rf ${CACHEDIR}/old
 mkdir -p ${CACHEDIR}/old
 cp -ar ${CACHEDIR}/*  ${CACHEDIR}/old/ 2>/dev/null
 
-/usr/bin/mm2_refresh_mirrorlist_cache
+/usr/bin/mm2_refresh_mirrorlist_cache $@
 
 exit 0


### PR DESCRIPTION
If the mirrorlist data exporter is writing pkl and protobuf files at the same time some database queries are running twice, which can take a lot of time. This change moves all database queries in the populate_all_caches() function which is the correct place. Previously some queries were run in populate_all_caches() and some in dump_ccaches().

This commit also includes a single line change to mm2_update-mirrorlist-server to forward all parameters to the actual data exporter script.

Verified in Fedora's mirrormanager2 instance.