### PR TITLE
Disallow users accessing other hosts and sites

### DIFF
--- a/mirrormanager2/app.py
+++ b/mirrormanager2/app.py
@@ -341,6 +341,10 @@ def site_view(site_id):
     if siteobj is None:
         flask.abort(404, 'Site not found')
 
+    if not (is_site_admin(flask.g.fas_user, siteobj)
+            or is_mirrormanager_admin(flask.g.fas_user)):
+        flask.abort(403, 'Access denied')
+
     form = forms.AddSiteForm(obj=siteobj)
     if form.validate_on_submit():
         admin_active = siteobj.admin_active
@@ -608,6 +612,10 @@ def host_view(host_id):
     if hostobj is None:
         flask.abort(404, 'Host not found')
 
+    if not (is_site_admin(flask.g.fas_user, hostobj.site)
+            or is_mirrormanager_admin(flask.g.fas_user)):
+        flask.abort(403, 'Access denied')
+
     form = forms.AddHostForm(obj=hostobj)
     if form.validate_on_submit():
         admin_active = hostobj.admin_active
@@ -824,6 +832,10 @@ def host_asn_new(host_id):
     if hostobj is None:
         flask.abort(404, 'Host not found')
 
+    if not (is_site_admin(flask.g.fas_user, hostobj.site)
+            or is_mirrormanager_admin(flask.g.fas_user)):
+        flask.abort(403, 'Access denied')
+
     form = forms.AddHostAsnForm()
     if form.validate_on_submit():
         host_asn = model.HostPeerAsn()
@@ -866,6 +878,10 @@ def host_asn_delete(host_id, host_asn_id):
 
         if hostobj is None:
             flask.abort(404, 'Host not found')
+
+        if not (is_site_admin(flask.g.fas_user, hostobj.site)
+                or is_mirrormanager_admin(flask.g.fas_user)):
+            flask.abort(403, 'Access denied')
 
         hostasnobj = mmlib.get_host_peer_asn(SESSION, host_asn_id)
 

--- a/tests/test_ui_app.py
+++ b/tests/test_ui_app.py
@@ -301,6 +301,10 @@ class FlaskUiAppTest(tests.Modeltests):
             data = output.get_data(as_text=True)
             self.assertTrue('<p>Site not found</p>' in data)
 
+            # Test if accessing other sites is not allowed
+            output = self.app.get('/site/1')
+            self.assertEqual(output.status_code, 403)
+
             output = self.app.get('/site/2')
             self.assertEqual(output.status_code, 200)
             data = output.get_data(as_text=True)
@@ -645,12 +649,16 @@ class FlaskUiAppTest(tests.Modeltests):
             data = output.get_data(as_text=True)
             self.assertTrue('<p>Host not found</p>' in data)
 
+            # Test if accessing other hosts is not allowed
             output = self.app.get('/host/3')
+            self.assertEqual(output.status_code, 403)
+
+            output = self.app.get('/host/2')
             self.assertEqual(output.status_code, 200)
             data = output.get_data(as_text=True)
             self.assertTrue(
-                '<h2>Host private.localhost' in data)
-            self.assertTrue('Back to <a href="/site/1">' in data)
+                '<h2>Host mirror2.localhost' in data)
+            self.assertTrue('Back to <a href="/site/2">' in data)
 
             csrf_token = data.split(
                 'name="csrf_token" type="hidden" value="')[1].split('">')[0]
@@ -660,13 +668,13 @@ class FlaskUiAppTest(tests.Modeltests):
                 'name': 'private.localhost.1',
             }
 
-            output = self.app.post('/host/3', data=post_data,
+            output = self.app.post('/host/2', data=post_data,
                                    follow_redirects=True)
             self.assertEqual(output.status_code, 200)
             data = output.get_data(as_text=True)
             self.assertTrue(
-                '<h2>Host private.localhost' in data)
-            self.assertTrue('Back to <a href="/site/1">' in data)
+                '<h2>Host mirror2.localhost' in data)
+            self.assertTrue('Back to <a href="/site/2">' in data)
             self.assertEqual(data.count('field is required.'), 3)
 
             post_data = {
@@ -682,25 +690,25 @@ class FlaskUiAppTest(tests.Modeltests):
 
             # Check CSRF protection
 
-            output = self.app.post('/host/3', data=post_data,
+            output = self.app.post('/host/2', data=post_data,
                                    follow_redirects=True)
             self.assertEqual(output.status_code, 200)
             data = output.get_data(as_text=True)
             self.assertTrue(
-                '<h2>Host private.localhost' in data)
-            self.assertTrue('Back to <a href="/site/1">' in data)
+                '<h2>Host mirror2.localhost' in data)
+            self.assertTrue('Back to <a href="/site/2">' in data)
 
             # Update site
 
             post_data['csrf_token'] = csrf_token
 
-            output = self.app.post('/host/3', data=post_data,
+            output = self.app.post('/host/2', data=post_data,
                                    follow_redirects=True)
             self.assertEqual(output.status_code, 200)
             data = output.get_data(as_text=True)
             self.assertTrue(
                 '<h2>Host private.localhost.1' in data)
-            self.assertTrue('Back to <a href="/site/1">' in data)
+            self.assertTrue('Back to <a href="/site/2">' in data)
 
     def test_host_netblock_new(self):
         """ Test the host_netblock_new endpoint. """


### PR DESCRIPTION
Without this change it was possible to manually inspect other Hosts and Sites by replacing the Site-ID or Host-ID with another ID. This adds the necessary checks to all Site and Host related actions.

Broken tests have been fixed and extended.