### PR TITLE
umdl: skip certain paths for version detection

### DIFF
--- a/mirrormanager2/default_config.py
+++ b/mirrormanager2/default_config.py
@@ -152,3 +152,7 @@ CRAWLER_RSYNC_PARAMETERS = '--no-motd --timeout 14400'
 # If a host fails for CRAWLER_AUTO_DISABLE times in a row
 # the host will be disable automatically (user_active)
 CRAWLER_AUTO_DISABLE = 4
+
+# This is a list of directories which MirrorManager will ignore while guessing
+# the version and architecture from a path.
+SKIP_PATHS_FOR_VERSION = ['pub/alt']

--- a/mirrormanager2/lib/umdl.py
+++ b/mirrormanager2/lib/umdl.py
@@ -120,7 +120,14 @@ def setup_arch_version_cache(session):
         version_cache = mirrormanager2.lib.get_versions(session)
 
 
-def guess_ver_arch_from_path(session, category, path):
+def guess_ver_arch_from_path(session, category, path, config=None):
+    if config:
+        dname = os.path.join(category.topdir.name, path)
+        skip_dirs = config.get('SKIP_PATHS_FOR_VERSION', [])
+        for skip in skip_dirs:
+            if dname.startswith(skip):
+                return (None, None)
+
     arch = None
     if 'SRPMS' in path:
         arch = mirrormanager2.lib.get_arch_by_name(session, 'source')
@@ -317,7 +324,13 @@ def make_repo_file_details(session, config, relativeDName, D, category, target):
         session.flush()
 
 
-def make_repository(session, directory, relativeDName, category, target):
+def make_repository(
+        session,
+        directory,
+        relativeDName,
+        category,
+        target,
+        config=None):
 
     logger.info(
         "Checking into Repo %s - %s - cat: %s - target: %s"
@@ -333,7 +346,7 @@ def make_repository(session, directory, relativeDName, category, target):
 
     if target == 'repomd.xml':
         (ver, arch) = guess_ver_arch_from_path(
-            session, category, relativeDName)
+            session, category, relativeDName, config)
         if ver is None or arch is None:
             logger.warning("%s: could not guess version and arch %r, %r" % (
                 warning, ver, arch))

--- a/utility/mirrormanager2.cfg.sample
+++ b/utility/mirrormanager2.cfg.sample
@@ -139,7 +139,9 @@ APPLICATION_URL = None
 # in front of the application).
 CHECK_SESSION_IP = True
 
-
+# This is a list of directories which MirrorManager will ignore while guessing
+# the version and architecture from a path.
+SKIP_PATHS_FOR_VERSION = ['pub/alt']
 
 ###
 # Configuration options used by the crons

--- a/utility/mm2_update-master-directory-list
+++ b/utility/mm2_update-master-directory-list
@@ -610,7 +610,7 @@ def sync_category_directory(
         skip_dir = [ u'Cloud', u'Workstation', u'Server' ]
         if not any(x in relativeDName for x in skip_dir):
             umdl.make_repository(
-                session, D, relativeDName, category, 'repomd.xml')
+                session, D, relativeDName, category, 'repomd.xml', config)
 
     if ('repomd.xml' in files) and (set_ctime or created):
         umdl.make_repo_file_details(


### PR DESCRIPTION
UMDL sometimes creates version entries in the database in locations which do not actually carry are release/version. In Fedora this happens most of the time with pub/alt. This adds a configuration variable which tells umdl to skip these directories.

Fixes: #263 