### PR TITLE
Disable report_mirror for public mirrors

### DIFF
--- a/mirrormanager2/lib/hostconfig.py
+++ b/mirrormanager2/lib/hostconfig.py
@@ -108,6 +108,13 @@ def read_host_config(session, config):
                 'Config file site name or password incorrect.\n'
         )
 
+    if site.private == False:
+        return (
+                None,
+                chostname,
+                'Only private mirrors are allowed to use report_mirror.\n'
+        )
+
     host = None
     for tmp_host in site.hosts:
         if tmp_host.name == chost['name']:
@@ -116,6 +123,13 @@ def read_host_config(session, config):
 
     if not host:
         return (None, chostname, 'Config file host name for site not found.\n')
+
+    if host.private == False:
+        return (
+                None,
+                chostname,
+                'Only private mirrors are allowed to use report_mirror.\n'
+        )
 
     # handle the optional arguments
     if 'user_active' in config['host']:


### PR DESCRIPTION
One of the limitations of the current report_mirror implementation is that it only transmits a list of directories to MirrorManager. That works most of the times, but a common error scenario we are seeing is that the crawler detects that a mirror is out of sync but report_mirror is still running. This leads to the situation that correctly deactivated mirrors by the crawler are enabled again. This is one of the most common problems we are seeing in Fedora with mirrors.

For private mirrors we still need report_mirror, but for public mirror this commit turns the report_mirror interface off.