### PR TITLE
Add support to handle fedora-cisco-openh264-*

### DIFF
--- a/mirrormanager2/lib/repomap.py
+++ b/mirrormanager2/lib/repomap.py
@@ -55,6 +55,8 @@ def repo_prefix(path, category, ver):
     isCentOS = (category.name == u'CentOS')
     isRhel = (category.name == u'RHEL')
 
+    isCodecs = (category.name == u'Fedora Codecs')
+
     version = u'unknown'
     if not isRawhide and ver is not None:
         version = ver.name
@@ -358,5 +360,11 @@ def repo_prefix(path, category, ver):
 
     elif isCentOS:
         prefix = centos_prefix(path)
+
+    elif isCodecs:
+        debug = u''
+        if isDebug:
+            debug = u'debug-'
+        prefix = 'fedora-cisco-openh264-%s%s' % (debug, version)
 
     return prefix

--- a/mirrormanager2/lib/umdl.py
+++ b/mirrormanager2/lib/umdl.py
@@ -71,7 +71,7 @@ def _get_version_from_path(path):
     if m is not None:
         return m.group(1)
     # Fedora versioning
-    s = r'/?(([\.\d]+)([-_]\w+)?)/'
+    s = r'/(([\.\d]+)([-_]\w+)?)/'
     m = re.search(re.compile(s), path)
     if m is not None:
         return m.group(1)


### PR DESCRIPTION
This adds fedora-cisco-openh264-* repository detection to repomap.py and adapts _get_version_from_path() to correctly detect versions in the openh264 tree.

The 'fix' for the version detection is a revert of the followingoriginal MirrorManager code:
```
 commit 131d6ee4e5870de467ccef5bf60108e7641caace
 Author: Adrian Reber <adrian@lisas.de>
 Date:   Tue Nov 16 07:00:41 2010 -0600

     umdl: handle CentOS
```