### PR TITLE
Add specific check for duplicate cat URLS

### DIFF
--- a/mirrormanager2/views.py
+++ b/mirrormanager2/views.py
@@ -960,6 +960,10 @@ def host_category_url_new(host_id, hc_id):
             url = url[:-1]
         host_category_u.url = url
 
+        if url in [url.url for url in hcobj.urls]:
+            flask.flash(f"URL Not Added: {url} already exists on {hcobj.category.name}", "error")
+            return flask.redirect(flask.url_for("base.host_view", host_id=host_id))
+
         # If the user is *not* an admin, keep the current private flag
         if not is_mirrormanager_admin(flask.g.fas_user):
             host_category_u.private = private

--- a/tests/test_ui_app.py
+++ b/tests/test_ui_app.py
@@ -1101,7 +1101,7 @@ def test_host_category_url_new_auth(client, user):
     output = client.post("/host/2/category/3/url/new", data=post_data, follow_redirects=True)
     assert output.status_code == 200
     data = output.get_data(as_text=True)
-    assert "Could not add Category URL to the host" in data
+    assert "URL Not Added: http://pingoured.fr/pub/Fedora already exists on Fedora Linux" in data
     assert '<h2 class="mb-0"><span class="fa fa-server"></span>' in data
     assert "<title>Host - MirrorManager</title>" in data
     assert 'action="/host/2/category/3/url/9/delete">' in data


### PR DESCRIPTION
previously, if a user tried to create a category URL that already existed in a category, it was caught as a SQLALCHEMY integrity error, and the application did not crash. However we just printed the exception to the logs, and it looked like an error. This commit adds some error checking to see if the URL already exitst, and informs the user as such.

Resolves: #317