### PR TITLE
Use the message schemas

### DIFF
--- a/mirrormanager2/crawler/cli.py
+++ b/mirrormanager2/crawler/cli.py
@@ -13,7 +13,7 @@ from mirrormanager2.lib.database import get_db_manager
 from mirrormanager2.lib.fedora import get_current_versions
 
 from .constants import CONTINENTS, DEFAULT_GLOBAL_TIMEOUT
-from .crawler import PropagationResult, worker
+from .crawler import CrawlResult, PropagationResult, worker
 from .log import setup_logging
 from .reporter import store_crawl_result
 from .threads import GlobalTimeoutError, run_in_threadpool
@@ -260,7 +260,7 @@ def crawl(ctx, **kwargs):
     run_on_all_hosts(ctx.obj, options, record_crawl)
 
 
-def record_crawl(ctx_obj, options, results: list[PropagationResult]):
+def record_crawl(ctx_obj, options, results: list[CrawlResult]):
     console = ctx_obj["console"]
     config = ctx_obj["config"]
     options = ctx_obj["options"]

--- a/mirrormanager2/lib/notifications.py
+++ b/mirrormanager2/lib/notifications.py
@@ -39,14 +39,9 @@ from fedora_messaging.message import Message
     (ConnectionException, PublishTimeout),
     max_tries=3,
 )
-def safe_publish(msg: Message):
-    fm_publish(msg)
-
-
-def fedmsg_publish(topic, content):  # pragma: no cover
+def fedmsg_publish(msg: Message):  # pragma: no cover
     """Try to publish a message on the fedmsg bus."""
-    msg = Message(body=content, topic=f"mirrormanager.{topic}")
-    safe_publish(msg)
+    fm_publish(msg)
 
 
 def email_publish(

--- a/poetry.lock
+++ b/poetry.lock
@@ -1390,6 +1390,20 @@ files = [
 ]
 
 [[package]]
+name = "mirrormanager-messages"
+version = "1.0.0"
+description = "A schema package for messages sent by MirrorManager"
+optional = false
+python-versions = "<4.0.0,>=3.8.10"
+files = [
+    {file = "mirrormanager_messages-1.0.0-py3-none-any.whl", hash = "sha256:5c7b2945f78ea5eddad65786494660f27c3d5410ac05fdc7d681c8a9b123d851"},
+    {file = "mirrormanager_messages-1.0.0.tar.gz", hash = "sha256:29b238af3021737f99810d417c143f2daf42ea7388c2688cfdeb303672925088"},
+]
+
+[package.dependencies]
+fedora-messaging = ">=3.3.0,<4.0.0"
+
+[[package]]
 name = "mrtparse"
 version = "2.2.0"
 description = "MRT format data parser"
@@ -2752,4 +2766,4 @@ deploy = ["gunicorn", "psycopg2"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "8d83a083e298a1031969862112b762db06438a897b1ef595ec17595d7ff985e8"
+content-hash = "16d80cbdf6ebbedb4be2ef3e7dd5ee24e708292a7a700c4750362267f3684d64"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ psycopg2 = {version = "^2.9.9", optional = true}
 rich = "^13.7.0"
 mrtparse = "^2.2.0"
 requests = "^2.31.0"
+mirrormanager-messages = "^1.0.0"
 
 [tool.poetry.group.dev.dependencies]
 black = ">=22.6.0"


### PR DESCRIPTION
Use the message schemas provided by `mirrormanager-messages`. The changes to `crawler/notif.py` aren't tested, but we don't emit Fedora Messaging messages from the crawler at the moment.

Fix: #353