### PR TITLE
Replace IPy with ipaddress

### DIFF
--- a/mirrormanager2/forms.py
+++ b/mirrormanager2/forms.py
@@ -140,10 +140,8 @@ def validate_netblocks(form, field):
     emsg += " can only be created by mirrormanager administrators."
     emsg += " Please ask the mirrormanager administrators for assistance."
 
-    ipv4_block = ipaddress.IPv4Network(f"10.0.0.0{max_ipv4_netblock_size}",
-                                       strict=False)
-    ipv6_block = ipaddress.IPv6Network(f"fec0::{max_ipv6_netblock_size}",
-                                       strict=False)
+    ipv4_block = ipaddress.IPv4Network(f"10.0.0.0{max_ipv4_netblock_size}", strict=False)
+    ipv6_block = ipaddress.IPv6Network(f"fec0::{max_ipv6_netblock_size}", strict=False)
 
     try:
         ip = ipaddress.ip_network(field.data, strict=False)

--- a/poetry.lock
+++ b/poetry.lock
@@ -1202,16 +1202,6 @@ files = [
 ]
 
 [[package]]
-name = "ipy"
-version = "1.01"
-description = "Class and tools for handling of IPv4 and IPv6 addresses and networks"
-optional = false
-python-versions = "*"
-files = [
-    {file = "IPy-1.01.tar.gz", hash = "sha256:edeca741dea2d54aca568fa23740288c3fe86c0f3ea700344571e9ef14a7cc1a"},
-]
-
-[[package]]
 name = "itsdangerous"
 version = "2.2.0"
 description = "Safely pass data to untrusted environments and back."
@@ -2968,4 +2958,4 @@ deploy = ["gunicorn", "psycopg2"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "a0e5634626ceb342a2823dafd92ebce1a6bb6b9c8bbccf24a9e59a486c188eff"
+content-hash = "a7b83790f58d4e9907bd27b67d57f0d7606fa099adf96649a6fd63c38b2ff715"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,6 @@ flask-oidc = "^2.0.0"
 flask-xml-rpc-re = "^0.1.4"
 flask-wtf = "^1.1.1"
 wtforms = {extras = ["email"], version = "^3.0.1"}
-ipy = "^1.1"
 backoff = "^2.2.1"
 fedora-messaging = "^3.3.0"
 sqlalchemy-helpers = "^1.0.0"

--- a/utility/mirrormanager2.spec
+++ b/utility/mirrormanager2.spec
@@ -24,7 +24,6 @@ BuildRequires:  python%{python_pkgversion}-flask-oidc >= 2.0.0
 BuildRequires:  python%{python_pkgversion}-flask-xml-rpc
 BuildRequires:  python%{python_pkgversion}-flask-wtf
 BuildRequires:  python%{python_pkgversion}-wtforms
-BuildRequires:  python%{python_pkgversion}-IPy
 BuildRequires:  python%{python_pkgversion}-backoff
 BuildRequires:  python%{python_pkgversion}-fedora-messaging
 BuildRequires:  python%{python_pkgversion}-sqlalchemy-helpers
@@ -70,7 +69,14 @@ Summary:        Library to interact with MirrorManager's database
 BuildArch:      noarch
 
 Requires:  %{name}-filesystem = %{version}-%{release}
+<<<<<<< HEAD
 Requires:  python%{python_pkgversion}-IPy
+||||||| parent of 0216c75 (Replace IPy with ipaddress)
+Requires:  python%{python_pkgversion}-IPy
+Requires:  python%{python_pkgversion}-dns
+=======
+Requires:  python%{python_pkgversion}-dns
+>>>>>>> 0216c75 (Replace IPy with ipaddress)
 Requires:  python%{python_pkgversion}-pyrpmmd
 
 %description lib


### PR DESCRIPTION
The Python standary library includes ipaddress packages since Python 3.3. Therefore, the IPy can be replaced