### PR TITLE
Remove six dependency

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2958,4 +2958,4 @@ deploy = ["gunicorn", "psycopg2"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "a7b83790f58d4e9907bd27b67d57f0d7606fa099adf96649a6fd63c38b2ff715"
+content-hash = "fc49e6b9f3b04a487e0d3a379cb58778004115d94dd5aa943b18a84e66559a6a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,6 @@ rich = "^13.7.0"
 mrtparse = "^2.2.0"
 requests = "^2.31.0"
 mirrormanager-messages = "^1.0.0"
-six = "^1.16.0"
 
 [tool.poetry.group.dev.dependencies]
 black = ">=22.6.0"


### PR DESCRIPTION
Python 2 is no longer supported for mirrormanager2. Therefore, the dependency to six can be removed.